### PR TITLE
Add support for acronyms (i.e. XYZComponent) in hybrids map.

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -3,8 +3,7 @@ export function camelToDash(str) {
 }
 
 export function pascalToDash(str) {
-  str = str[0].toLowerCase() + str.slice(1);
-  return camelToDash(str);
+  return camelToDash(str.replace(/((?!([A-Z]{2}|^))[A-Z])/g, '-$1'));
 }
 
 export function dispatch(host, eventType, options = {}) {

--- a/test/spec/define.js
+++ b/test/spec/define.js
@@ -12,12 +12,19 @@ describe('define:', () => {
   describe('for map argument', () => {
     it('defines hybrids', (done) => {
       const testHtmlDefine = { value: 'test' };
-      define({ testHtmlDefine });
-      define({ testHtmlDefine });
+      const TestPascal = { value: 'value-test-pascal' };
+      const HTMLDefine = { value: 'value-html-define' };
+      define({ testHtmlDefine, TestPascal, HTMLDefine });
 
       requestAnimationFrame(() => {
-        const el = document.createElement('test-html-define');
-        expect(el.value).toBe('test');
+        const testHtmlDefineEl = document.createElement('test-html-define');
+        const testPascalEl = document.createElement('test-pascal');
+        const htmlDefineEl = document.createElement('html-define');
+
+        expect(testHtmlDefineEl.value).toBe('test');
+        expect(testPascalEl.value).toBe('value-test-pascal');
+        expect(htmlDefineEl.value).toBe('value-html-define');
+
         done();
       });
     });


### PR DESCRIPTION
The current implementation of ```pascalToDash``` does not account for acronyms. This is slightly problematic when using the ```define``` function with a map of Hybrids descriptor objects because a key like ```XYZComponent``` is not correctly converted to a tag name like ```xyz-component```.