### PR TITLE
feat: change detection mechanism refactor

### DIFF
--- a/docs/built-in-factories/property.md
+++ b/docs/built-in-factories/property.md
@@ -20,13 +20,22 @@ const MyElement = {
 
 Property factory holds a property value with the type transform with fallback to the corresponding attribute value.
 
-The [translation](../core-concepts/translation.md) has two rules, which use property factory. You can set property value as primitive or an object without `get` and `set` methods to define it using property factory.
+### Translation
+
+The [translation](../core-concepts/translation.md) allows using property factory implicitly. You can set a property as a primitive or an array to create descriptor by the property factory under the hood:
+
+```javascript
+const MyElement = {
+  value: 0,
+  items: [],
+};
+```
 
 ## Transform
 
-`property` uses a transform function, which ensures the strict type of the value set by a property or an attribute. 
+`property` factory uses a transform function, which ensures the strict type of the value set by property or an attribute.
 
-The type of the `defaultValue` is used to detect transform function. For example, when `defaultValue` is set to `"text"`, `String` function is used. If the `defaultValue` is a function, it is called when a property value is set.
+The type of `defaultValue` is used to detect the transform function. For example, when `defaultValue` is set to `"text"`, `String` function is used. If the `defaultValue` is a function, it is called when a property value is set.
 
 ### Transform Types
 
@@ -37,7 +46,7 @@ The type of the `defaultValue` is used to detect transform function. For example
 * `object` -> `Object.freeze(value)`
 * `undefined` -> `value`
 
-Object values are frozen to prevent mutation of the own properties, which does not invalidate cached value. Moreover, `defaultValue` is shared between custom element instances, so any of them should not change it.
+Object values are frozen to prevent mutation of their properties, which does not invalidate cached value. Moreover, `defaultValue` is shared between custom element instances, so any of them should not change it.
 
 To omit transform, `defaultValue` has to be set to `undefined`.
 

--- a/docs/core-concepts/definition.md
+++ b/docs/core-concepts/definition.md
@@ -9,6 +9,10 @@ To simplify using external custom elements with those created by the library, yo
 ```javascript
 import { define } from 'hybrids';
 
+const MyElement = {
+  ...
+};
+
 // Define one element with explicit tag name
 define('my-element', MyElement);
 ```

--- a/docs/core-concepts/descriptors.md
+++ b/docs/core-concepts/descriptors.md
@@ -1,8 +1,8 @@
 # Descriptors
 
-The library provides own `define` function, which under the hood calls Custom Element API (read more in [Definition](./definition.md) section). Because of that, the library has all control over the parameters of the custom element definition. It creates class wrapper constructor dynamically, applies properties on its prototype, and finally defines custom element using `customElements.define()` method.
+The library provides `define` function, which under the hood calls Custom Element API (read more in [Definition](./definition.md) section). Because of that, the library has all control over the parameters of the custom element definition. It creates class wrapper constructor dynamically, applies properties on its prototype, and finally defines custom element using `customElements.define()` method.
 
-Property definitions are known as a *property descriptor*. The name came from the third argument of the `Object.defineProperty(obj, prop, descriptor)` method, which is used to set those properties on the `prototype` of the custom element constructor.
+The property definition is known as a *property descriptor*. The name came from the third argument of the `Object.defineProperty(obj, prop, descriptor)` method, which is used to set those properties on the `prototype` of the custom element constructor.
 
 ## Structure
 
@@ -15,19 +15,23 @@ const MyElement = {
     set: (host, value, lastValue) => { ... },
     connect: (host, key, invalidate) => {
       ...
-      return () => { ... }; // disconnect
+      // disconnect
+      return () => { ... };
     },
+    observe: (host, value, lastValue) => { ... },
   },
 };
 ```
 
 However, there are a few differences. Instead of using function context (`this` keyword), the first argument of all methods is the instance of an element. It allows using arrow functions and destructuring function arguments.
 
-The second most change is the cache mechanism, which controls and holds current property value. By the specs, getter/setter property requires external variable for keeping the value. In the hybrids, cache covers that for you.
+The second most change is the cache mechanism, which controls and holds current property value. By the specs, getter/setter property requires an external variable for keeping the value. In the hybrids, cache covers that for you. Additionally, the library provides a mechanism for change detection and calls `observe` method, when the value of the property has changed (directly or when one of the dependency changes).
 
-**Despite the [factories](factories.md) and [translation](translation.md) concepts, you can always define properties using descriptors**. The only requirement is that your definition has to include at least one of the `get`, `set` or `connect` methods. 
+**Despite the [factories](factories.md) and [translation](translation.md) concepts, you can always define properties using descriptors**. The only requirement is that your definition has to be an object instance (instead of a function reference, an array instance or primitive value).
 
-The library uses default `get` or `set` method if they are not defined. The fallback method returns last saved value for `get`, and saves passed value for `set`. If `get` method is defined, `set` method does not fallback to default. It allows creating read-only property.
+## Defaults
+
+The library provides a default method for `get` or `set` if they are omitted in the definition. The fallback method returns last saved value for `get`, and saves passed value for `set`. If the `get` method is defined, the `set` method does not support fallback to default (it allows creating read-only property).
 
 ```javascript
 const MyElement = {
@@ -42,25 +46,30 @@ const MyElement = {
     // get: (host, value) => value,
     set: () => {...},
   },
-  defaultGetAndSet: {
+  defaultsWithConnect: {
     // get: (host, value) => value,
     // set: (host, value) => value,
     connect: () => {...},
   },
+  defaultsWithObserve: {
+    // get: (host, value) => value,
+    // set: (host, value) => value,
+    observe: () => {...},
+  },
 }
 ```
 
-In the above example `readonly` and `defaultGet` properties might have `connect` method but is not required. `defaultGetAndSet` applies only when `connect` method is defined.
+## Methods
 
-### Get
+### get
 
 ```typescript
 get: (host: Element, lastValue: any) => {
-  // calculate next value
-  const nextValue = ...;
+  // calculate current value
+  const value = ...;
 
   // return it
-  return nextValue;
+  return value;
 }
 ```
 
@@ -70,9 +79,11 @@ get: (host: Element, lastValue: any) => {
 * **returns (required)**:
   * `nextValue` - a value of the current state of the property
 
-`get` method calculates current property value. The returned value is cached by default. This method is called again only if other properties defined by the library used in the body of the function have changed. Cache mechanism uses equality check to compare values (`nextValue !== lastValue`), so it enforces using immutable data, which is one of the ground rules of the library.
+It calculates the current property value. The returned value is cached by default. The cache mechanism works between properties defined by the library (even between different elements). If your `get` method does not use other properties, it won't be called again (the only way to update the value then is to assert new value or call `invalidate` from `connect` method).
 
-In the following example `get` method of the `name` property is called again if `firstName` or `lastName` has changed:
+Cache mechanism uses equality check to compare values (`nextValue !== lastValue`), so it enforces using immutable data, which is one of the ground rules of the library.
+
+In the following example, the `get` method of the `name` property is called again if `firstName` or `lastName` has changed:
 
 ```javascript
 const MyElement = {
@@ -87,7 +98,7 @@ console.log(myElement.name); // calls 'get' and returns 'John Smith'
 console.log(myElement.name); // Cache returns 'John Smith'
 ```
 
-### Set
+### set
 
 ```typescript
 set: (host: Element, value: any, lastValue: any) => {
@@ -106,11 +117,9 @@ set: (host: Element, value: any, lastValue: any) => {
 * **returns (required)**: 
   * `nextValue` - a value of the property, which replaces cached value
 
-Every assertion of the property calls `set` method (like `myElement.property = 'new value'`). Cache value is invalidated if returned `nextValue` is not equal to `lastValue`. Only if cache invalidates `get` method is called. 
+Every assertion of the property calls `set` method (like `myElement.property = 'new value'`). If returned `nextValue` is not equal to `lastValue`, cache of the property invalidates. However, `set` method does not trigger `get` method automatically. Only the next access to the property (like `const value = myElement.property`) calls `get` method. Then `get` takes `nextValue` from `set` as the `lastValue` argument, calculates `value` and returns it.
 
-However, `set` method doesn't call `get` immediately. The next access to the property calls `get` method, although `set` returned a new value. Then `get` method takes this value as the `lastValue` argument, calculates `nextValue` and returns new value.
-
-The following example shows `power` property using the default `get`, and defined `set` method, which calculates the power of the number passed to the property:
+The following example shows the `power` property, which uses the default `get`, defines the `set` method, and calculates the power of the number passed to the property:
 
 ```javascript
 const MyElement = {
@@ -123,9 +132,9 @@ myElement.power = 10; // calls 'set' method and set cache to 100
 console.log(myElement.power); // Cache returns 100
 ```
 
-If your property value only depends on other properties from the component, you can omit `set` method and use cache mechanism for holding property value (use only `get` method).
+If your property value only depends on other properties from the component, you can omit the `set` method and use the cache mechanism for holding property value (use only the `get` method).
 
-### Connect & Disconnect
+### connect
 
 ```typescript
 connect: (host: Element, key: string, invalidate: Function) => {
@@ -150,17 +159,9 @@ connect: (host: Element, key: string, invalidate: Function) => {
 
 When you insert, remove or relocate an element in the DOM tree, `connect` or `disconnect` is called synchronously (in the `connectedCallback` and `disconnectedCallback` callbacks of the Custom Elements API).
 
-You can use `connect` to attach event listeners, initialize property value (using `key` argument) and many more. To clean up subscriptions return a `disconnect` function, where you can remove attached listeners and other things.
+You can use `connect` to attach event listeners, initialize property value (using `key` argument) and many more. To clean up subscriptions, return a `disconnect` function, where you can remove attached listeners and other things.
 
-## Change detection
-
-```javascript
-myElement.addEventListener('@invalidate', () => { ...});
-```
-
-When property cache value invalidates, change detection dispatches `@invalidate` custom event (bubbling). You can listen to this event and observe changes in the element properties. It is dispatched implicit when you set new value by the assertion or explicit by calling `invalidate` in `connect` callback. The event type was chosen to avoid name collision with those created by the custom elements authors.
-
-If the third party code is responsible for the property value, you can use `invalidate` callback to update it and trigger event dispatch. For example, it can be used to connect to async web APIs or external libraries:
+If the third party code is responsible for the property value, you can use `invalidate` callback to notify that value should be recalculated (within next access). For example, it can be used to connect to async web APIs or external libraries:
 
 ```javascript
 import reduxStore from './store';
@@ -176,3 +177,21 @@ const MyElement = {
 👆 [Click and play with `redux` integration on ⚡StackBlitz](https://stackblitz.com/edit/hybrids-redux-counter?file=redux-counter.js)
 
 In the above example, a cached value of `name` property invalidates if `reduxStore` changes. However, the `get` method is called if you access the property.
+
+### observe
+
+```typescript
+observe: (host: Element, value: any, lastValue: any) => {
+  // Do side-effects related to value change
+  ...
+}
+```
+
+* **arguments**:
+  * `host` - an element instance
+  * `value` - current value of the property
+  * `lastValue` - last cached value of the property
+
+When property cache invalidates (directly by the assertion or when one of the dependency invalidates) and `observe` method is set, the change detection mechanism adds the property to the internal queue. Within the next animation frame (using `requestAnimationFrame`) properties from the queue are checked if they have changed, and if they did, `observe` method of the property is called. It means, that `observe` method is asynchronous by default, and it is only called for properties, which value is different in the time of execution of the queue (in the `requestAnimationFrame` call).
+
+The property is added to the queue (if `observe` is set) for the first time when an element instance is created (in the `constructor()` of the element). Property value defaults to `undefined`. The `observe` method will be called at the start only if your `get` method returns other value than `undefined`.

--- a/src/children.js
+++ b/src/children.js
@@ -1,5 +1,3 @@
-import { deferred } from './utils';
-
 function walk(node, fn, options, items = []) {
   Array.from(node.children).forEach((child) => {
     const hybrids = child.constructor.hybrids;
@@ -22,34 +20,12 @@ export default function children(hybridsOrFn, options = { deep: false, nested: f
     get(host) { return walk(host, fn, options); },
     connect(host, key, invalidate) {
       const observer = new MutationObserver(invalidate);
-      const set = new Set();
-
-      const childEventListener = ({ target }) => {
-        if (!set.size) {
-          deferred.then(() => {
-            const list = host[key];
-            for (let i = 0; i < list.length; i += 1) {
-              if (set.has(list[i])) {
-                invalidate(false);
-                break;
-              }
-            }
-            set.clear();
-          });
-        }
-        set.add(target);
-      };
 
       observer.observe(host, {
         childList: true, subtree: !!options.deep,
       });
 
-      host.addEventListener('@invalidate', childEventListener);
-
-      return () => {
-        observer.disconnect();
-        host.removeEventListener('@invalidate', childEventListener);
-      };
+      return () => { observer.disconnect(); };
     },
   };
 }

--- a/src/emitter.js
+++ b/src/emitter.js
@@ -1,0 +1,42 @@
+const targets = new WeakMap();
+
+function getListeners(target) {
+  let listeners = targets.get(target);
+  if (!listeners) {
+    listeners = new Set();
+    targets.set(target, listeners);
+  }
+  return listeners;
+}
+
+const queue = new Set();
+const run = fn => fn();
+
+function execute() {
+  try {
+    queue.forEach((target) => {
+      try {
+        getListeners(target).forEach(run);
+        queue.delete(target);
+      } catch (e) {
+        queue.delete(target);
+        throw e;
+      }
+    });
+  } catch (e) {
+    if (queue.size) execute();
+    throw e;
+  }
+}
+
+export function dispatch(target) {
+  if (!queue.size) {
+    requestAnimationFrame(execute);
+  }
+  queue.add(target);
+}
+
+export function subscribe(target, cb) {
+  getListeners(target).add(cb);
+  dispatch(target);
+}

--- a/src/parent.js
+++ b/src/parent.js
@@ -21,19 +21,9 @@ export default function parent(hybridsOrFn) {
     get: host => walk(host, fn),
     connect(host, key, invalidate) {
       const target = host[key];
-      const cb = (event) => {
-        if (event.target === target) invalidate(false);
-      };
-
       if (target) {
-        target.addEventListener('@invalidate', cb);
-
-        return () => {
-          target.removeEventListener('@invalidate', cb);
-          invalidate();
-        };
+        return invalidate;
       }
-
       return false;
     },
   };

--- a/src/render.js
+++ b/src/render.js
@@ -1,113 +1,29 @@
-import { deferred, shadyCSS } from './utils';
-
-const map = new WeakMap();
-const cache = new WeakMap();
-
-let queue = [];
-let index = 0;
-let startTime = 0;
-
-const FPS_THRESHOLD = 1000 / 60; // 60 FPS ~ 16,67ms time window
-
-export function update() {
-  try {
-    let offset = 1;
-
-    startTime = performance.now();
-
-    for (; index < queue.length; index += 1) {
-      const target = queue[index];
-
-      if (map.has(target)) {
-        const key = map.get(target);
-        const prevUpdate = cache.get(target);
-        const nextUpdate = target[key];
-
-        if (nextUpdate !== prevUpdate) {
-          cache.set(target, nextUpdate);
-          nextUpdate();
-          if (!prevUpdate) {
-            shadyCSS(shady => shady.styleElement(target));
-          } else {
-            shadyCSS(shady => shady.styleSubtree(target));
-          }
-        }
-
-        if (index % offset === 0) {
-          if (index + 1 < queue.length && (performance.now() - startTime) > FPS_THRESHOLD) {
-            throw queue;
-          } else {
-            offset *= 2;
-          }
-        }
-      }
-    }
-
-    queue = [];
-    index = 0;
-    deferred.then(() => { startTime = 0; });
-  } catch (e) {
-    index += 1;
-    requestAnimationFrame(update);
-    deferred.then(() => { startTime = 0; });
-
-    if (e !== queue) throw e;
-  }
-}
-
-function addToQueue(event) {
-  if (event.target === event.currentTarget && map.has(event.target)) {
-    if (!startTime) {
-      if (!queue.length) {
-        requestAnimationFrame(update);
-      } else {
-        queue.splice(index, 0, event.target);
-        return;
-      }
-    } else if (!queue.length) {
-      if ((performance.now() - startTime) > FPS_THRESHOLD) {
-        requestAnimationFrame(update);
-      } else {
-        deferred.then(update);
-      }
-    }
-
-    queue.push(event.target);
-  }
-}
-
 export default function render(get, customOptions = {}) {
   if (typeof get !== 'function') {
     throw TypeError(`The first argument must be a function: ${typeof get}`);
   }
 
   const options = { shadowRoot: true, ...customOptions };
+  const shadowRootInit = { mode: 'open' };
+
+  if (typeof options.shadowRoot === 'object') {
+    Object.assign(shadowRootInit, options.shadowRoot);
+  }
 
   return {
-    get: (host) => {
+    get(host) {
       const fn = get(host);
-      return () => fn(host, options.shadowRoot ? host.shadowRoot : host);
+      return function flush() {
+        fn(host, options.shadowRoot ? host.shadowRoot : host);
+      };
     },
-    connect(host, key) {
-      if (map.has(host)) {
-        throw Error(`Render factory already used in '${map.get(host)}' key`);
-      }
-
+    connect(host) {
       if (options.shadowRoot && !host.shadowRoot) {
-        const shadowRootInit = { mode: 'open' };
-        if (typeof options.shadowRoot === 'object') {
-          Object.assign(shadowRootInit, options.shadowRoot);
-        }
         host.attachShadow(shadowRootInit);
       }
-
-      host.addEventListener('@invalidate', addToQueue);
-      map.set(host, key);
-
-      return () => {
-        host.removeEventListener('@invalidate', addToQueue);
-        map.delete(host);
-      };
+    },
+    observe(host, fn) {
+      fn();
     },
   };
 }

--- a/src/template/index.js
+++ b/src/template/index.js
@@ -1,9 +1,10 @@
 import defineElements from '../define';
 
-import { compile, getPlaceholder } from './core';
+import { compileTemplate, getPlaceholder } from './core';
 import * as helpers from './helpers';
 
 const PLACEHOLDER = getPlaceholder();
+const SVG_PLACEHOLDER = getPlaceholder('svg');
 
 const templatesMap = new Map();
 const stylesMap = new WeakMap();
@@ -24,22 +25,22 @@ const methods = {
 };
 
 function create(parts, args, isSVG) {
-  const fn = (host, target = host) => {
-    const styles = stylesMap.get(fn);
+  const createTemplate = (host, target = host) => {
+    const styles = stylesMap.get(createTemplate);
     let id = parts.join(PLACEHOLDER);
     if (styles) id += styles.join(PLACEHOLDER);
-    if (isSVG) id += getPlaceholder('svg');
+    if (isSVG) id += SVG_PLACEHOLDER;
 
     let render = templatesMap.get(id);
     if (!render) {
-      render = compile(parts, isSVG, styles);
+      render = compileTemplate(parts, isSVG, styles);
       templatesMap.set(id, render);
     }
 
     render(host, target, args);
   };
 
-  return Object.assign(fn, methods);
+  return Object.assign(createTemplate, methods);
 }
 
 export function html(parts, ...args) {

--- a/src/template/resolvers/array.js
+++ b/src/template/resolvers/array.js
@@ -54,7 +54,8 @@ export default function resolveArray(host, target, value) {
   const lastIndex = value.length - 1;
   const data = dataMap.get(target);
 
-  entries.forEach((entry, index) => {
+  for (let index = 0; index < entries.length; index += 1) {
+    const entry = entries[index];
     let matchedEntry;
     if (lastEntries) {
       for (let i = 0; i < lastEntries.length; i += 1) {
@@ -88,7 +89,7 @@ export default function resolveArray(host, target, value) {
     if (index === lastIndex) data.endNode = previousSibling;
 
     entry.placeholder = placeholder;
-  });
+  }
 
   if (lastEntries) {
     lastEntries.forEach((entry) => {

--- a/src/utils.js
+++ b/src/utils.js
@@ -33,5 +33,4 @@ export function stringifyElement(element) {
 }
 
 export const IS_IE = 'ActiveXObject' in window;
-
 export const deferred = Promise.resolve();

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -2,16 +2,25 @@ export function test(html) {
   const template = document.createElement('template');
   template.innerHTML = html;
 
-  return (spec) => {
+  return spec => (done) => {
     const wrapper = document.createElement('div');
     document.body.appendChild(wrapper);
-
     wrapper.appendChild(template.content.cloneNode(true));
-    const promise = spec(wrapper.children[0]);
+    const result = spec(wrapper.children[0]);
 
-    Promise.resolve(promise).then(() => {
-      document.body.removeChild(wrapper);
-    });
+    if (result) {
+      Promise.resolve(result).then(() => {
+        requestAnimationFrame(() => {
+          document.body.removeChild(wrapper);
+          done();
+        });
+      });
+    } else {
+      requestAnimationFrame(() => {
+        document.body.removeChild(wrapper);
+        done();
+      });
+    }
   };
 }
 

--- a/test/spec/children.js
+++ b/test/spec/children.js
@@ -14,6 +14,7 @@ describe('children:', () => {
     define('test-children-direct', {
       direct: children(child),
       customName: ({ direct }) => direct && direct[0] && direct[0].customName,
+      render: ({ customName }) => html`${customName}`,
     });
 
     const tree = test(`
@@ -28,25 +29,24 @@ describe('children:', () => {
       </test-children-direct>
     `);
 
-    it('returns list', () => tree((el) => {
+    it('returns list', tree((el) => {
       expect(el.direct).toEqual([
         el.children[0],
         el.children[1],
       ]);
     }));
 
-    it('removes item from list', done => tree((el) => {
+    it('removes item from list', tree((el) => {
       el.removeChild(el.children[1]);
 
       return resolveRaf(() => {
         expect(el.direct).toEqual([
           jasmine.objectContaining({ customName: 'one' }),
         ]);
-        done();
       });
     }));
 
-    it('adds item to list', done => tree((el) => {
+    it('adds item to list', tree((el) => {
       const newItem = document.createElement('test-children-child');
       newItem.customName = 'four';
 
@@ -58,11 +58,10 @@ describe('children:', () => {
           jasmine.objectContaining({ customName: 'two' }),
           jasmine.objectContaining({ customName: 'four' }),
         ]);
-        done();
       });
     }));
 
-    it('reorder list items', done => tree((el) => {
+    it('reorder list items', tree((el) => {
       el.insertBefore(el.children[1], el.children[0]);
 
       return resolveRaf(() => {
@@ -70,23 +69,15 @@ describe('children:', () => {
           jasmine.objectContaining({ customName: 'two' }),
           jasmine.objectContaining({ customName: 'one' }),
         ]);
-        done();
       });
     }));
 
-    it('updates parent computed property', done => tree(el => resolveTimeout(() => {
+    it('updates parent computed property', tree(el => resolveTimeout(() => {
       expect(el.customName).toBe('one');
       el.children[0].customName = 'four';
-      let called = false;
-
-      el.addEventListener('@invalidate', ({ target }) => {
-        if (target === el) called = true;
-      });
 
       return resolveRaf(() => {
-        expect(called).toBe(true);
-        expect(el.customName).toBe('four');
-        done();
+        expect(el.shadowRoot.innerHTML).toBe('four');
       });
     })));
   });
@@ -102,7 +93,7 @@ describe('children:', () => {
       </test-children-fn>
     `);
 
-    it('returns item list', () => tree((el) => {
+    it('returns item list', tree((el) => {
       expect(el.direct.length).toBe(1);
       expect(el.direct[0]).toBe(el.children[0]);
     }));
@@ -125,7 +116,7 @@ describe('children:', () => {
       </test-children-deep>
     `);
 
-    it('returns item list', () => tree((el) => {
+    it('returns item list', tree((el) => {
       expect(el.deep).toEqual([
         jasmine.objectContaining({ customName: 'one' }),
         jasmine.objectContaining({ customName: 'two' }),
@@ -133,7 +124,7 @@ describe('children:', () => {
       ]);
     }));
 
-    it('removes item from list', done => tree((el) => {
+    it('removes item from list', tree((el) => {
       el.children[2].innerHTML = '';
 
       return resolveRaf(() => {
@@ -141,11 +132,10 @@ describe('children:', () => {
           jasmine.objectContaining({ customName: 'one' }),
           jasmine.objectContaining({ customName: 'two' }),
         ]);
-        done();
       });
     }));
 
-    it('does not update if other children element is invalidated', done => tree(el => resolveRaf(() => {
+    it('does not update if other children element is invalidated', tree(el => resolveRaf(() => {
       el.children[0].children[0].customName = 'test';
       return resolveRaf(() => {
         expect(el.deep).toEqual([
@@ -153,7 +143,6 @@ describe('children:', () => {
           jasmine.objectContaining({ customName: 'two' }),
           jasmine.objectContaining({ customName: 'three' }),
         ]);
-        done();
       });
     })));
   });
@@ -175,7 +164,7 @@ describe('children:', () => {
       </test-children-nested>
     `);
 
-    it('returns item list', () => tree((el) => {
+    it('returns item list', tree((el) => {
       expect(el.nested).toEqual([
         jasmine.objectContaining({ customName: 'one' }),
         jasmine.objectContaining({ customName: 'five' }),
@@ -184,7 +173,7 @@ describe('children:', () => {
       ]);
     }));
 
-    it('removes item from list', done => tree((el) => {
+    it('removes item from list', tree((el) => {
       el.children[0].innerHTML = '';
 
       return resolveRaf(() => {
@@ -193,7 +182,6 @@ describe('children:', () => {
           jasmine.objectContaining({ customName: 'two' }),
           jasmine.objectContaining({ customName: 'three' }),
         ]);
-        done();
       });
     }));
   });
@@ -229,11 +217,10 @@ describe('children:', () => {
       <test-dynamic-wrapper></test-dynamic-wrapper>
     `);
 
-    it('adds dynamic item', done => tree(el => resolveTimeout(() => {
+    it('adds dynamic item', tree(el => resolveTimeout(() => {
       el.items = ['two'];
       return resolveTimeout(() => {
         expect(el.shadowRoot.children[0].shadowRoot.children[0].children.length).toBe(2);
-        done();
       });
     })));
   });

--- a/test/spec/emitter.js
+++ b/test/spec/emitter.js
@@ -1,0 +1,78 @@
+import { dispatch, subscribe } from '../../src/emitter';
+
+describe('emitter:', () => {
+  let spy;
+  let target;
+
+  beforeEach(() => {
+    spy = jasmine.createSpy();
+    target = {};
+  });
+
+  it('subscribe saves fn and dispatch target in next animation frame', (done) => {
+    subscribe(target, spy);
+    requestAnimationFrame(() => {
+      expect(spy).toHaveBeenCalledTimes(1);
+      done();
+    });
+  });
+
+  describe('dispatch', () => {
+    let origRAF;
+    let catchSpy;
+
+    beforeEach(() => {
+      catchSpy = jasmine.createSpy();
+    });
+
+    beforeAll(() => {
+      origRAF = window.requestAnimationFrame;
+      window.requestAnimationFrame = function requestAnimationFrame(fn) {
+        origRAF.call(this, () => {
+          try {
+            fn();
+          } catch (e) {
+            catchSpy(fn);
+          }
+        });
+      };
+    });
+
+    afterAll(() => {
+      window.requestAnimationFrame = origRAF;
+    });
+
+    it('calls fn for target', (done) => {
+      subscribe(target, spy);
+      requestAnimationFrame(() => {
+        dispatch(target);
+        requestAnimationFrame(() => {
+          expect(spy).toHaveBeenCalledTimes(2);
+          done();
+        });
+      });
+    });
+
+    it('catches error', (done) => {
+      subscribe(target, () => { throw new Error('asd'); });
+
+      requestAnimationFrame(() => {
+        expect(catchSpy).toHaveBeenCalledTimes(1);
+        done();
+      });
+    });
+
+    it('catches error and calls next target', (done) => {
+      const target2 = {};
+
+      subscribe(target, () => { throw new Error('asd'); });
+      subscribe(target2, spy);
+
+      requestAnimationFrame(() => {
+        expect(catchSpy).toHaveBeenCalledTimes(1);
+        expect(spy).toHaveBeenCalledTimes(1);
+        done();
+      });
+    });
+  });
+});

--- a/test/spec/parent.js
+++ b/test/spec/parent.js
@@ -44,12 +44,12 @@ describe('parent:', () => {
     </test-parent-parent>
   `);
 
-  it('connects with direct parent element', () => directParentTree((el) => {
+  it('connects with direct parent element', directParentTree((el) => {
     const child = el.children[0];
     expect(child.parent).toBe(el);
   }));
 
-  it('disconnects from parent element', done => directParentTree((el) => {
+  it('disconnects from parent element', directParentTree((el) => {
     const child = el.children[0];
     expect(child.parent).toBe(el);
 
@@ -58,16 +58,15 @@ describe('parent:', () => {
 
     return Promise.resolve().then(() => {
       expect(child.parent).toBe(null);
-      done();
     });
   }));
 
-  it('connects to indirect parent element', () => indirectParentTree((el) => {
+  it('connects to indirect parent element', indirectParentTree((el) => {
     const child = el.children[0].children[0];
     expect(child.parent).toBe(el);
   }));
 
-  it('connects to out of the shadow parent element', () => shadowParentTree((el) => {
+  it('connects to out of the shadow parent element', shadowParentTree((el) => {
     const shadowRoot = el.attachShadow({ mode: 'open' });
     const child = document.createElement('test-parent-child');
     const wrapper = document.createElement('div');
@@ -77,35 +76,25 @@ describe('parent:', () => {
     expect(child.parent).toBe(el);
   }));
 
-  it('connects to parent by a function argument', () => fnParentTree((el) => {
+  it('connects to parent by a function argument', fnParentTree((el) => {
     const child = el.children[0];
     expect(child.parent).toBe(el);
   }));
 
-  it('returns null for no parent', () => noParentTree((el) => {
+  it('returns null for no parent', noParentTree((el) => {
     expect(el.parent).toBe(null);
   }));
 
-  it('updates child computed property', done => directParentTree((el) => {
-    Promise.resolve().then(() => {
-      const spy = jasmine.createSpy('event callback');
-      const child = el.children[0];
+  it('updates child computed property', directParentTree(el => Promise.resolve().then(() => {
+    const child = el.children[0];
 
-      expect(el.customProperty).toBe('value');
-      expect(child.computed).toBe('value other value');
+    expect(el.customProperty).toBe('value');
+    expect(child.computed).toBe('value other value');
 
-      child.addEventListener('@invalidate', spy);
+    el.customProperty = 'new value';
 
-      el.customProperty = 'new value';
-
-      Promise.resolve().then(() => {
-        Promise.resolve().then(() => {
-          expect(spy).toHaveBeenCalledTimes(1);
-          expect(child.computed).toBe('new value other value');
-
-          done();
-        });
-      });
-    });
-  }));
+    return Promise.resolve().then(() => Promise.resolve().then(() => {
+      expect(child.computed).toBe('new value other value');
+    }));
+  })));
 });

--- a/test/spec/property.js
+++ b/test/spec/property.js
@@ -26,15 +26,15 @@ describe('property:', () => {
       <test-property string-prop="default value"></test-property>
     `);
 
-    it('uses value from configuration', () => empty((el) => {
+    it('uses value from configuration', empty((el) => {
       expect(el.stringProp).toBe('value');
     }));
 
-    it('uses host attribute', () => tree((el) => {
+    it('uses host attribute', tree((el) => {
       expect(el.stringProp).toBe('default value');
     }));
 
-    it('uses host attribute value only once', done => tree((el) => {
+    it('uses host attribute value only once', tree((el) => {
       const parent = el.parentElement;
 
       el.stringProp = 'new value';
@@ -45,7 +45,6 @@ describe('property:', () => {
 
         Promise.resolve().then(() => {
           expect(el.stringProp).toBe('new value');
-          done();
           resolve();
         });
       });
@@ -69,11 +68,11 @@ describe('property:', () => {
       <test-property number-prop="321"></test-property>
     `);
 
-    it('transforms attribute to number', () => tree((el) => {
+    it('transforms attribute to number', tree((el) => {
       expect(el.numberProp).toBe(321);
     }));
 
-    it('transforms property to number', () => empty((el) => {
+    it('transforms property to number', empty((el) => {
       el.numberProp = '321';
       expect(el.numberProp).toBe(321);
     }));
@@ -84,17 +83,19 @@ describe('property:', () => {
       <test-property bool-prop></test-property>
     `);
 
-    it('transforms attribute to boolean', () => {
+    it('transforms unset attribute to boolean', (done) => {
       empty((el) => {
         expect(el.boolProp).toBe(false);
-      });
-
-      tree((el) => {
-        expect(el.boolProp).toBe(true);
-      });
+      })(done);
     });
 
-    it('transforms property to number', () => empty((el) => {
+    it('transforms set attribute to boolean', (done) => {
+      tree((el) => {
+        expect(el.boolProp).toBe(true);
+      })(done);
+    });
+
+    it('transforms property to number', empty((el) => {
       el.boolProp = 'value';
       expect(el.boolProp).toBe(true);
 
@@ -122,7 +123,7 @@ describe('property:', () => {
       });
     });
 
-    it('transforms property with function', () => empty((el) => {
+    it('transforms property with function', empty((el) => {
       el.funcProp = false;
       expect(el.funcProp).toEqual({
         value: false,
@@ -135,13 +136,11 @@ describe('property:', () => {
       <test-property obj-prop="asd"></test-property>
     `);
 
-    it('does not transform attribute', () => {
-      tree((el) => {
-        expect(el.objProp).toBe(objProp);
-      });
-    });
+    it('does not transform attribute', tree((el) => {
+      expect(el.objProp).toBe(objProp);
+    }));
 
-    it('set object value', () => empty((el) => {
+    it('set object value', empty((el) => {
       const value = {};
       el.objProp = value;
       expect(el.objProp).toBe(value);
@@ -150,7 +149,7 @@ describe('property:', () => {
       expect(el.objProp).toBe(null);
     }));
 
-    it('throws when set with other type than object', () => empty((el) => {
+    it('throws when set with other type than object', empty((el) => {
       expect(() => { el.objProp = false; }).toThrow();
     }));
   });
@@ -160,25 +159,22 @@ describe('property:', () => {
       <test-property null-prop="test value" undefined-prop="test value"></test-property>
     `);
 
-    it('does not transform attribute', () => {
-      empty((el) => {
-        expect(el.nullProp).toBe(null);
-        expect(el.undefinedProp).toBe(undefined);
-      });
+    it('does not transform attribute', empty((el) => {
+      expect(el.nullProp).toBe(null);
+      expect(el.undefinedProp).toBe(undefined);
+    }));
+    it('does not transform attribute', tree((el) => {
+      expect(el.nullProp).toBe(null);
+      expect(el.undefinedProp).toBe(undefined);
+    }));
 
-      tree((el) => {
-        expect(el.nullProp).toBe(null);
-        expect(el.undefinedProp).toBe(undefined);
-      });
-    });
-
-    it('passes null property without transform', () => empty((el) => {
+    it('passes null property without transform', empty((el) => {
       const obj = {};
       el.nullProp = obj;
       expect(el.nullProp).toBe(obj);
     }));
 
-    it('passes undefined property without transform', () => empty((el) => {
+    it('passes undefined property without transform', empty((el) => {
       el.undefinedProp = false;
       expect(el.undefinedProp).toBe(false);
 
@@ -189,13 +185,13 @@ describe('property:', () => {
   });
 
   describe('connect option', () => {
-    it('is called', () => {
+    it('is called', (done) => {
       const spy = jasmine.createSpy('connect');
       define('test-property-connect', {
         prop: property(0, spy),
       });
 
-      test('<test-property-connect></test-property-connect>')(() => expect(spy).toHaveBeenCalledTimes(1));
+      test('<test-property-connect></test-property-connect>')(() => expect(spy).toHaveBeenCalledTimes(1))(done);
     });
   });
 });

--- a/test/spec/render.js
+++ b/test/spec/render.js
@@ -1,6 +1,6 @@
-import { test, resolveRaf, resolveTimeout } from '../helpers';
+import { test, resolveRaf } from '../helpers';
 import { define, html } from '../../src';
-import render, { update } from '../../src/render';
+import render from '../../src/render';
 
 describe('render:', () => {
   define('test-render', {
@@ -23,43 +23,23 @@ describe('render:', () => {
     }).toThrow();
   });
 
-  it('renders content', done => tree(el => resolveRaf(() => {
+  it('renders content', tree(el => resolveRaf(() => {
     expect(el.shadowRoot.children[0].textContent).toBe('0');
-    done();
   })));
 
-  it('updates content', done => tree(el => resolveRaf(() => {
+  it('updates content', tree(el => resolveRaf(() => {
     el.value = 1;
     return resolveRaf(() => {
       expect(el.shadowRoot.children[0].textContent).toBe('1');
-      done();
     });
   })));
 
-  it('does not render when element is out of the document', done => tree((el) => {
-    const fragment = document.createDocumentFragment();
-    fragment.appendChild(el);
-
-    return resolveRaf(() => {
-      expect(el.shadowRoot.innerHTML).toBe('');
-      done();
-    });
-  }));
-
-  it('does not render if getter does not change', done => tree(el => resolveRaf(() => {
-    el.property = 'new value';
-    return resolveRaf(() => {
-      expect(el.shadowRoot.children[0].textContent).toBe('0');
-      done();
-    });
-  })));
-
-  it('renders content on direct call', () => tree((el) => {
+  it('renders content on direct call', tree((el) => {
     el.render();
     expect(el.shadowRoot.children[0].textContent).toBe('0');
   }));
 
-  it('does not re-create shadow DOM', done => tree((el) => {
+  it('does not re-create shadow DOM', tree((el) => {
     const shadowRoot = el.shadowRoot;
     const parent = el.parentElement;
     parent.removeChild(el);
@@ -67,151 +47,8 @@ describe('render:', () => {
     return resolveRaf(() => {
       parent.appendChild(el);
       expect(el.shadowRoot).toBe(shadowRoot);
-      done();
     });
   }));
-
-  describe('defer next update tasks after threshold', () => {
-    define('test-render-long', {
-      nested: false,
-      delay: false,
-      value: '',
-      render: ({ nested, delay, value }) => (target, shadowRoot) => {
-        let template = `<div>${value}</div>`;
-
-        if (nested) {
-          template += `
-            <test-render-long delay></test-render-long>
-            <test-render-long delay></test-render-long>
-          `;
-        }
-        if (delay) {
-          const now = performance.now();
-          while (performance.now() - now < 20);
-        }
-
-        shadowRoot.innerHTML = template;
-      },
-    });
-
-    it('renders nested elements', done => test(`
-      <div>
-        <test-render-long nested value="one"></test-render-long>
-      </div>
-    `)(el => new Promise((resolve) => {
-      requestAnimationFrame(() => {
-        requestAnimationFrame(() => {
-          requestAnimationFrame(() => {
-            const one = el.children[0];
-            expect(one.shadowRoot.children[0].textContent).toBe('one');
-            resolve();
-            done();
-          });
-        });
-      });
-    })));
-
-    it('renders nested elements with delay', done => test(`
-      <div>
-        <test-render-long nested delay value="one"></test-render-long>
-      </div>
-    `)(el => new Promise((resolve) => {
-      requestAnimationFrame(() => {
-        requestAnimationFrame(() => {
-          requestAnimationFrame(() => {
-            const one = el.children[0];
-            expect(one.shadowRoot.children[0].textContent).toBe('one');
-            resolve();
-            done();
-          });
-        });
-      });
-    })));
-  });
-
-  it('update function catches error in render function', (done) => {
-    let fn = () => { throw Error(); };
-    define('test-render-throws-in-render', {
-      render: () => fn(),
-    });
-
-    test('<test-render-throws-in-render></test-render-throws-in-render>')(() => {
-      Promise.resolve().then(() => {
-        expect(() => {
-          update();
-        }).toThrow();
-        fn = () => {};
-        done();
-      });
-    });
-  });
-
-  it('update function catches error in result of render function', (done) => {
-    let fn = () => { throw Error('example error'); };
-    define('test-render-throws-in-callback', {
-      render: () => fn,
-    });
-
-    test('<test-render-throws-in-callback></test-render-throws-in-callback>')(() => {
-      Promise.resolve().then(() => {
-        expect(() => {
-          update();
-        }).toThrow();
-        fn = () => {};
-        done();
-      });
-    });
-  });
-
-  describe('shady css custom property scope', () => {
-    const TestShadyChild = {
-      value: 0,
-      render: ({ value }) => html`
-        <span>${value}</span>
-        <style>
-          span {
-            color: var(--custom-color);
-          }
-        </style>
-      `,
-    };
-
-    const TestShadyParent = {
-      active: false,
-      render: ({ active }) => html`
-        <test-shady-child class="${{ active }}"></test-shady-child>
-        <style>
-          test-shady-child {
-            --custom-color: red;
-          }
-          test-shady-child.active {
-            --custom-color: blue;
-          }
-        </style>
-      `.define({ TestShadyChild }),
-    };
-
-    define('test-shady-parent', TestShadyParent);
-
-    const shadyTree = test(`
-      <test-shady-parent></test-shady-parent>
-    `);
-
-    it('should set custom property', done => shadyTree(el => resolveTimeout(() => {
-      const { color } = window.getComputedStyle(el.shadowRoot.children[0].shadowRoot.children[0]);
-      expect(color).toBe('rgb(255, 0, 0)');
-      done();
-    })));
-
-    it('should update custom property', done => shadyTree(el => resolveTimeout(() => {
-      el.active = true;
-      return resolveTimeout(() => {
-        const { color } = window.getComputedStyle(el.shadowRoot.children[0].shadowRoot.children[0]);
-        expect(color).toBe('rgb(0, 0, 255)');
-        done();
-      });
-    })));
-  });
 
   it('renders elements in parent slot', (done) => {
     const TestRenderParentSlot = {
@@ -228,58 +65,7 @@ describe('render:', () => {
 
     slotTree(el => resolveRaf(() => {
       expect(el.children[0].shadowRoot.children[0].textContent).toBe('0');
-      done();
-    }));
-  });
-
-  it('throws error for duplicate render', () => {
-    const hybrids = {
-      renderOne: render(() => () => {}),
-      renderTwo: render(() => () => {}),
-    };
-
-    const el = document.createElement('div');
-
-    expect(() => {
-      hybrids.renderOne.connect(el, 'renderOne');
-      hybrids.renderTwo.connect(el, 'renderTwo');
-    }).toThrow();
-  });
-
-  describe('shadyCSS polyfill', () => {
-    const shadyCSSApplied = window.ShadyCSS && !window.ShadyCSS.nativeShadow;
-
-    beforeAll(() => {
-      if (!shadyCSSApplied) {
-        window.ShadyCSS = {
-          prepareTemplate: template => template,
-          styleElement: jasmine.createSpy(),
-          styleSubtree: jasmine.createSpy(),
-        };
-      } else {
-        spyOn(window.ShadyCSS, 'styleElement');
-        spyOn(window.ShadyCSS, 'styleSubtree');
-      }
-    });
-
-    afterAll(() => {
-      if (!shadyCSSApplied) {
-        delete window.ShadyCSS;
-      }
-    });
-
-    it('uses styleElement on first paint', done => tree(() => resolveTimeout(() => {
-      expect(window.ShadyCSS.styleElement).toHaveBeenCalled();
-      done();
-    })));
-
-    it('uses styleSubtree on sequential paint', done => tree(el => resolveRaf(() => {
-      el.value = 1;
-      return resolveTimeout(() => {
-        expect(window.ShadyCSS.styleSubtree).toHaveBeenCalled();
-        done();
-      });
-    })));
+    }))(done);
   });
 
   describe('options object with shadowRoot option', () => {
@@ -310,24 +96,29 @@ describe('render:', () => {
           expect(el.children.length).toBe(2);
           expect(el.children[0].innerHTML).toBe('other content');
           expect(el.children[1].innerHTML).toBe('false');
-          done();
         });
-      }));
+      }))(done);
     });
 
-    it('for object creates shadowRoot with "delegatesFocus" option', () => {
+    it('for object creates shadowRoot with "delegatesFocus" option', (done) => {
       const TestRenderCustomShadow = define('test-render-custom-shadow', {
         render: render(() => html`
           <input type="text" />
         `, { shadowRoot: { delegatesFocus: true } }),
       });
-      const spy = spyOn(TestRenderCustomShadow.prototype, 'attachShadow');
+      const origAttachShadow = TestRenderCustomShadow.prototype.attachShadow;
+      const spy = jasmine.createSpy('attachShadow');
+
+      TestRenderCustomShadow.prototype.attachShadow = function attachShadow(...args) {
+        spy(...args);
+        return origAttachShadow.call(this, ...args);
+      };
 
       test(`
         <test-render-custom-shadow></test-render-custom-shadow>
       `)(() => {
         expect(spy).toHaveBeenCalledWith({ mode: 'open', delegatesFocus: true });
-      });
+      })(done);
     });
   });
 });


### PR DESCRIPTION
Change detection mechanism relays on DOM events. This has two significant drawbacks:
* We can only attach cache mechanism to objects that are HTML elements
* DOM events API is slow and complicates observing children factory due to listening bubbling event

This PR introduces a new change detection mechanism:

* It's based on internal emitter
* Allows observing changes in other properties like it was implemented in `render` factory (scheduler)
* Decauples cache from HTML elements - allows creating `store` factory with objects related to HTML elements with a proper cache mechanism connected between them

From now, instead of using `@invalidate` event, you have to use the `observe` method of the descriptor:

```javascript
MyElement = {
  property: {
    get(host, lastValue) {...},
    set(host, value) {...},
    observe(host, value, lastValue) {
       // call side effects here when property value changes
    },
};
```

## Breaking Changes

* Use `observe` method  instead of `addEventListener('@invaldiate', ...)`