### PR TITLE
Fixing error message

### DIFF
--- a/src/property.js
+++ b/src/property.js
@@ -4,7 +4,7 @@ const defaultTransform = v => v;
 
 const objectTransform = (value) => {
   if (typeof value !== 'object') {
-    throw TypeError(`Assigned value must be an object: ${typeof v}`);
+    throw TypeError(`Assigned value must be an object: ${typeof value}`);
   }
   return value && Object.freeze(value);
 };


### PR DESCRIPTION
Looks like we're referencing an undeclared variable `v` and will always print out `Assigned value must be an object: undefined`