### PR TITLE
Add `reflect` transformer to reflect property changes to DOM attributes and vice-versa

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hybrids",
-  "version": "4.0.2",
+  "version": "4.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -4694,7 +4694,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4715,12 +4716,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4735,17 +4738,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4862,7 +4868,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4874,6 +4881,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4888,6 +4896,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4895,12 +4904,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -4919,6 +4930,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4999,7 +5011,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5011,6 +5024,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5096,7 +5110,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5132,6 +5147,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5151,6 +5167,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5194,12 +5211,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -4694,8 +4694,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4716,14 +4715,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4738,20 +4735,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4868,8 +4862,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4881,7 +4874,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4896,7 +4888,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4904,14 +4895,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -4930,7 +4919,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5011,8 +4999,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5024,7 +5011,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5110,8 +5096,7 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5147,7 +5132,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5167,7 +5151,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5211,14 +5194,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hybrids",
-  "version": "4.0.2",
+  "version": "4.0.3",
   "description": "Web Components from plain objects and pure functions!",
   "main": "lib/index.js",
   "module": "esm/index.js",

--- a/src/define.js
+++ b/src/define.js
@@ -178,19 +178,16 @@ function defineElement(tagName, hybridsOrConstructor) {
 
       if (newValue === null) { // Attribute has been completely removed.
         switch (propType) {
-          case Number:
-            this[prop] = NaN;
-            break;
           case Boolean:
             this[prop] = false;
             break;
-          case String:
-          case Function:
-          case Object:
+          case Number:
+            this[prop] = NaN;
+            break;
+          default:
             this[prop] = undefined;
             debugger;
             break;
-          default: break;
         }
       } else {
         this[prop] = coerceValue(newValue, propType);

--- a/src/define.js
+++ b/src/define.js
@@ -171,17 +171,16 @@ function defineElement(tagName, hybridsOrConstructor) {
     }
 
     static get observedAttributes() {
-      return Object.keys(hybridsOrConstructor).filter(x => x !== 'render');
-    }
-
-    getTransform() {
-
+      return Object.entries(hybridsOrConstructor).reduce((acc, [attr, methods]) => {
+        if (methods.reflect) acc.push(attr);
+        return acc;
+      }, []);
     }
 
     attributeChangedCallback(name, oldValue, newValue) {
       if (oldValue === newValue) return;
       let type = typeof this[name];
-      if (type === 'undefined') {
+      if (type === 'undefined' || type === 'boolean') {
         if (oldValue === null && newValue === '') {
           type = 'boolean';
           newValue = true;
@@ -205,6 +204,7 @@ function defineElement(tagName, hybridsOrConstructor) {
           transform = Boolean;
           break;
         case 'function':
+          debugger;
           transform = value;
           value = transform();
           break;

--- a/src/define.js
+++ b/src/define.js
@@ -178,28 +178,26 @@ function defineElement(tagName, hybridsOrConstructor) {
     }
 
     attributeChangedCallback(name, oldValue, newValue) {
+      if (oldValue === newValue) return;
       const propName = dashToCamel(name);
       const descriptors = Hybrid.hybrids;
       
       const desc = descriptors[propName];
-      let type = desc.reflect;
+      let attrType = desc.reflect;
 
-      // debugger
-      // if (type === 'object') {
-        if (oldValue === null && newValue === '') {
-          type = 'boolean';
-          newValue = true;
-          oldValue = false;
-        } else if (oldValue === '' && newValue === null) {
-          type = 'boolean';
-          newValue = false;
-          oldValue = true;
-        }
-      // } 
+      if (oldValue === null && newValue === '') {
+        attrType = 'boolean';
+        newValue = true;
+        oldValue = false;
+      } else if (oldValue === '' && newValue === null) {
+        attrType = 'boolean';
+        newValue = false;
+        oldValue = true;
+      }
 
       let transform = defaultTransform;
 
-      switch (type) {
+      switch (attrType) {
         case 'string':
           transform = String;
           break;
@@ -222,14 +220,9 @@ function defineElement(tagName, hybridsOrConstructor) {
         default: break;
       }
     
-      console.log('aaa')
-      debugger;
-
       newValue = transform(newValue);
       oldValue = transform(oldValue);
       if (newValue !== oldValue) {
-        console.log('defne')
-        debugger
         this[propName] = newValue;
       }
       // this[propName] = transform(newValue);

--- a/src/define.js
+++ b/src/define.js
@@ -106,13 +106,6 @@ const disconnects = new WeakMap();
 
 const defaultTransform = v => v;
 
-const objectTransform = (value) => {
-  if (typeof value !== 'object') {
-    throw TypeError(`Assigned value must be an object: ${typeof value}`);
-  }
-  return value && Object.freeze(value);
-};
-
 function defineElement(tagName, hybridsOrConstructor) {
   const type = typeof hybridsOrConstructor;
   if (type !== 'object' && type !== 'function') {
@@ -181,7 +174,7 @@ function defineElement(tagName, hybridsOrConstructor) {
       if (oldValue === newValue) return;
       const propName = dashToCamel(name);
       const descriptors = Hybrid.hybrids;
-      
+
       const desc = descriptors[propName];
       let attrType = desc.reflect;
 
@@ -208,26 +201,24 @@ function defineElement(tagName, hybridsOrConstructor) {
           transform = Boolean;
           break;
         case 'function':
-          debugger
+          debugger;
           // transform = value;
           // value = transform();
           break;
         case 'object':
-          debugger
+          debugger;
           // if (newValue) Object.freeze(newValue);
           // transform = objectTransform;
           break;
         default: break;
       }
-    
+
       newValue = transform(newValue);
       oldValue = transform(oldValue);
       if (newValue !== oldValue) {
         this[propName] = newValue;
       }
-      // this[propName] = transform(newValue);
     }
-
   }
 
   compile(Hybrid, hybridsOrConstructor);

--- a/src/define.js
+++ b/src/define.js
@@ -186,7 +186,6 @@ function defineElement(tagName, hybridsOrConstructor) {
             break;
           default:
             this[prop] = undefined;
-            debugger;
             break;
         }
       } else {

--- a/src/define.js
+++ b/src/define.js
@@ -3,7 +3,7 @@ import render from './render';
 
 import * as cache from './cache';
 import {
-  pascalToDash, deferred, dashToCamel, coerceValue,
+  pascalToDash, deferred, dashToCamel, coerceToType,
 } from './utils';
 
 /* istanbul ignore next */
@@ -189,7 +189,7 @@ function defineElement(tagName, hybridsOrConstructor) {
             break;
         }
       } else {
-        this[prop] = coerceValue(newValue, propType);
+        this[prop] = coerceToType(newValue, propType);
       }
     }
   }

--- a/src/define.js
+++ b/src/define.js
@@ -181,9 +181,6 @@ function defineElement(tagName, hybridsOrConstructor) {
           case Boolean:
             this[prop] = false;
             break;
-          case Number:
-            this[prop] = NaN;
-            break;
           default:
             this[prop] = undefined;
             break;

--- a/src/define.js
+++ b/src/define.js
@@ -184,15 +184,18 @@ function defineElement(tagName, hybridsOrConstructor) {
       const desc = descriptors[propName];
       let type = desc.reflect;
 
-      if (type === 'object') {
+      // debugger
+      // if (type === 'object') {
         if (oldValue === null && newValue === '') {
           type = 'boolean';
           newValue = true;
+          oldValue = false;
         } else if (oldValue === '' && newValue === null) {
           type = 'boolean';
           newValue = false;
+          oldValue = true;
         }
-      } 
+      // } 
 
       let transform = defaultTransform;
 
@@ -207,17 +210,29 @@ function defineElement(tagName, hybridsOrConstructor) {
           transform = Boolean;
           break;
         case 'function':
-          transform = value;
-          value = transform();
+          debugger
+          // transform = value;
+          // value = transform();
           break;
         case 'object':
-          if (newValue) Object.freeze(newValue);
-          transform = objectTransform;
+          debugger
+          // if (newValue) Object.freeze(newValue);
+          // transform = objectTransform;
           break;
         default: break;
       }
     
-      this[propName] = transform(newValue);
+      console.log('aaa')
+      debugger;
+
+      newValue = transform(newValue);
+      oldValue = transform(oldValue);
+      if (newValue !== oldValue) {
+        console.log('defne')
+        debugger
+        this[propName] = newValue;
+      }
+      // this[propName] = transform(newValue);
     }
 
   }

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ export { default as property } from './property';
 export { default as parent } from './parent';
 export { default as children } from './children';
 export { default as render } from './render';
+export { default as reflect } from './reflect';
 
 export { dispatch } from './utils';
 

--- a/src/property.js
+++ b/src/property.js
@@ -9,7 +9,7 @@ const objectTransform = (value) => {
   return value && Object.freeze(value);
 };
 
-export default function property(value, connect, observe) {
+export default function property(value, connect) {
   const type = typeof value;
   let transform = defaultTransform;
 
@@ -34,7 +34,6 @@ export default function property(value, connect, observe) {
     default: break;
   }
 
-  let attrName;
   return {
     get: (host, val = value) => val,
     set: (host, val, oldValue) => transform(val, oldValue),

--- a/src/property.js
+++ b/src/property.js
@@ -9,7 +9,7 @@ const objectTransform = (value) => {
   return value && Object.freeze(value);
 };
 
-export default function property(value, connect) {
+export default function property(value, connect, observe) {
   const type = typeof value;
   let transform = defaultTransform;
 
@@ -34,22 +34,58 @@ export default function property(value, connect) {
     default: break;
   }
 
+  let attrName;
   return {
     get: (host, val = value) => val,
     set: (host, val, oldValue) => transform(val, oldValue),
-    connect: type !== 'object' && type !== 'undefined'
-      ? (host, key, invalidate) => {
-        if (host[key] === value) {
-          const attrName = camelToDash(key);
+    // connect2: type !== 'object' && type !== 'undefined'
+    //   ? (host, key, invalidate) => {
+    //     if (host[key] === value) {
+    //       const attrName = camelToDash(key);
 
-          if (host.hasAttribute(attrName)) {
-            const attrValue = host.getAttribute(attrName);
-            host[key] = attrValue !== '' ? attrValue : true;
-          }
+    //       if (host.hasAttribute(attrName)) {
+    //         const attrValue = host.getAttribute(attrName);
+    //         host[key] = attrValue !== '' ? attrValue : true;
+    //       }
+    //     }
+
+    //     return connect && connect(host, key, invalidate);
+    //   }
+    //   : connect,
+    connect: (host, key, invalidate) => {
+      attrName = camelToDash(key);
+      if (host[key] === value) {
+        if (host.hasAttribute(attrName)) {
+          const attrValue = host.getAttribute(attrName);
+          host[key] = attrValue !== '' ? attrValue : true;
         }
-
-        return connect && connect(host, key, invalidate);
       }
-      : connect,
+
+      return connect && connect(host, key, invalidate);
+    },
+    observe: (host, val, oldValue) => {
+      if (val === oldValue) return;
+      
+      switch (type) {
+        case 'string':
+        case 'number':
+          host.setAttribute(attrName, val);
+          break;
+        case 'boolean':
+          val ? host.setAttribute(attrName, '') : host.removeAttribute(attrName);
+          break;
+        case 'function':
+          debugger;
+          transform = value;
+          value = transform();
+          break;
+        case 'object':
+          debugger;
+          if (value) Object.freeze(value);
+          transform = objectTransform;
+          break;
+        default: break;
+      }
+    }
   };
 }

--- a/src/property.js
+++ b/src/property.js
@@ -38,54 +38,19 @@ export default function property(value, connect, observe) {
   return {
     get: (host, val = value) => val,
     set: (host, val, oldValue) => transform(val, oldValue),
-    // connect2: type !== 'object' && type !== 'undefined'
-    //   ? (host, key, invalidate) => {
-    //     if (host[key] === value) {
-    //       const attrName = camelToDash(key);
+    connect: type !== 'object' && type !== 'undefined'
+      ? (host, key, invalidate) => {
+        if (host[key] === value) {
+          const attrName = camelToDash(key);
 
-    //       if (host.hasAttribute(attrName)) {
-    //         const attrValue = host.getAttribute(attrName);
-    //         host[key] = attrValue !== '' ? attrValue : true;
-    //       }
-    //     }
-
-    //     return connect && connect(host, key, invalidate);
-    //   }
-    //   : connect,
-    connect: (host, key, invalidate) => {
-      attrName = camelToDash(key);
-      if (host[key] === value) {
-        if (host.hasAttribute(attrName)) {
-          const attrValue = host.getAttribute(attrName);
-          host[key] = attrValue !== '' ? attrValue : true;
+          if (host.hasAttribute(attrName)) {
+            const attrValue = host.getAttribute(attrName);
+            host[key] = attrValue !== '' ? attrValue : true;
+          }
         }
-      }
 
-      return connect && connect(host, key, invalidate);
-    },
-    observe: (host, val, oldValue) => {
-      if (val === oldValue) return;
-      
-      switch (type) {
-        case 'string':
-        case 'number':
-          host.setAttribute(attrName, val);
-          break;
-        case 'boolean':
-          val ? host.setAttribute(attrName, '') : host.removeAttribute(attrName);
-          break;
-        case 'function':
-          debugger;
-          transform = value;
-          value = transform();
-          break;
-        case 'object':
-          debugger;
-          if (value) Object.freeze(value);
-          transform = objectTransform;
-          break;
-        default: break;
+        return connect && connect(host, key, invalidate);
       }
-    }
+      : connect,
   };
 }

--- a/src/reflect.js
+++ b/src/reflect.js
@@ -1,47 +1,61 @@
-import { camelToDash, coerceValue, setAttr } from './utils';
+import { camelToDash, coerceValue } from './utils';
 
-export default function reflect({ type, value, properties = {} }) {
+function getType(value) {
+  switch (typeof value) {
+    case 'number': return Number;
+    case 'boolean': return Boolean;
+    case 'object':
+      if (Array.isArray(value)) return Array;
+      return Object;
+    case 'function': return Function;
+    case 'string':
+    default: return String;
+  }
+}
+
+export default function reflect(value, properties = {}) {
   let attrName;
+  const type = getType(value);
   const reflectedProperties = {
     connect: (host, key) => {
       attrName = camelToDash(key);
       const attrValue = host.getAttribute(attrName);
-      debugger
-      const coercedAttrValue = coerceValue(attrValue, type);
-      const currentValue = attrValue === null ? value : coercedAttrValue;
-      host[key] = currentValue;
-
-      if (coercedAttrValue !== currentValue) {
-        setAttr(host, key, type, currentValue);
+      if (attrValue !== null) {
+        value = coerceValue(attrValue, type);
       }
+      if (host[key] === undefined) {
+        host[key] = value;
+      }
+
       if (properties.connect) {
         properties.connect(host, key);
       }
     },
     observe: (host, val, oldValue) => {
-      switch (type) {
-        case String:
-        case Number:
-          host.setAttribute(attrName, val);
-          break;
-        case Boolean:
-          if (val) {
-            host.setAttribute(attrName, '');
-          } else {
-            host.removeAttribute(attrName);
-          }
-          break;
-        case Array:
-          debugger
-          host.setAttribute(attrName, JSON.stringify(val));
-          break;
-        case Function:
-        case Object:
-        case Set:
-        case Map:
-          debugger;
-          break;
-        default: break;
+      if (val !== oldValue) {
+        switch (type) {
+          case Boolean:
+            if (val) {
+              host.setAttribute(attrName, '');
+            } else {
+              host.removeAttribute(attrName);
+            }
+            break;
+          case Array:
+          case Object:
+            host.setAttribute(attrName, JSON.stringify(val));
+            break;
+          case Function:
+          case Set:
+          case Map:
+            debugger;
+            break;
+          case String:
+          case Number:
+          default:
+            host.setAttribute(attrName, val);
+            break;
+        }  
       }
 
       if (properties.observe) properties.observe(host, val, oldValue);

--- a/src/reflect.js
+++ b/src/reflect.js
@@ -10,29 +10,55 @@ export default function reflect(value) {
       }
     },
     observe: (host, val, oldValue) => {
-      if (val !== oldValue) {
-        // const type = typeof val;
-        switch (type) {
-          case 'string':
-          case 'number':
-            host.setAttribute(attrName, val);
-            break;
-          case 'boolean':
-            val ? host.setAttribute(attrName, '') : host.removeAttribute(attrName);
-            break;
-          case 'function':
-            debugger;
-            // transform = value;
-            // value = transform();
-            break;
-          case 'object':
-            debugger;
-          //   if (value) Object.freeze(value);
-          //   transform = objectTransform;
-            break;
-          default: break;
-        }        
+      const oldType = typeof oldValue;
+      const newType = typeof val;
+      const type = newType !== 'undefined' ? newType : oldType;
+
+      switch (type) {
+        case 'string':
+        case 'number':
+          host.setAttribute(attrName, val);
+          break;
+        case 'boolean':
+          if (val) {
+            host.setAttribute(attrName, '');
+          } else {
+            host.removeAttribute(attrName);
+          }
+          break;
+        case 'function':
+        case 'object':
+          debugger;
+          break;
+        default: break;
       }
+
+      // console.log('aoeu')
+      // debugger
+
+      // if (val !== oldValue) {
+      //   // const type = typeof val;
+      //   switch (type) {
+      //     case 'string':
+      //     case 'number':
+      //       host.setAttribute(attrName, val);
+      //       break;
+      //     case 'boolean':
+      //       val ? host.setAttribute(attrName, '') : host.removeAttribute(attrName);
+      //       break;
+      //     case 'function':
+      //       debugger;
+      //       // transform = value;
+      //       // value = transform();
+      //       break;
+      //     case 'object':
+      //       debugger;
+      //     //   if (value) Object.freeze(value);
+      //     //   transform = objectTransform;
+      //       break;
+      //     default: break;
+      //   }        
+      // }
   
       if (isObject && value.observe) {
         value.observe(host, val, oldValue);

--- a/src/reflect.js
+++ b/src/reflect.js
@@ -1,0 +1,48 @@
+export default function reflect(value) {
+  const isObject = typeof value === 'object';
+  let attrName;
+  const reflectedMethods = {
+    connect: (host, key) => {
+      attrName = key;
+      if (isObject && value.connect) {
+        value.connect(host, key);
+      }
+    },
+    observe: (host, val, oldValue) => {
+      if (val !== oldValue) {
+        const type = typeof val;
+        switch (type) {
+          case 'string':
+          case 'number':
+            host.setAttribute(attrName, val);
+            break;
+          case 'boolean':
+            val ? host.setAttribute(attrName, '') : host.removeAttribute(attrName);
+            break;
+          case 'function':
+            debugger;
+            // transform = value;
+            // value = transform();
+            break;
+          case 'object':
+            debugger;
+          //   if (value) Object.freeze(value);
+          //   transform = objectTransform;
+            break;
+          default: break;
+        }        
+      }
+  
+      if (isObject && value.observe) {
+        value.observe(host, val, oldValue);
+      }
+    },
+    reflect: true,
+  }
+ 
+  if (isObject) {
+    return Object.assign({}, value, reflectedMethods);
+  } else {
+    return reflectedMethods;
+  }
+}

--- a/src/reflect.js
+++ b/src/reflect.js
@@ -19,6 +19,8 @@ export default function reflect(value, properties = {}) {
       }
     },
     observe: (host, val, oldValue) => {
+      const attrValue = host.getAttribute(attrName);
+      if (val === attrValue) return;
       if (val !== oldValue) {
         switch (type) {
           case null:
@@ -33,14 +35,28 @@ export default function reflect(value, properties = {}) {
             break;
           case Array:
           case Object:
-            host.setAttribute(attrName, JSON.stringify(val));
+            if (val === undefined || val === null) {
+              host.removeAttribute(attrName);
+            } else {
+              host.setAttribute(attrName, JSON.stringify(val));
+            }
             break;
           case Function:
             break;
           case String:
+            if (val === '' || val === undefined || val === null) {
+              host.removeAttribute(attrName);
+            } else {
+              host.setAttribute(attrName, val);
+            }
+            break;
           case Number:
           default:
-            host.setAttribute(attrName, val);
+            if (val === undefined || val === null) {
+              host.removeAttribute(attrName);
+            } else {
+              host.setAttribute(attrName, val);
+            }
             break;
         }
       }

--- a/src/reflect.js
+++ b/src/reflect.js
@@ -1,6 +1,6 @@
 import { camelToDash, coerceValue, setAttr } from './utils';
 
-export default function reflect({ type, value, properties }) {
+export default function reflect({ type, value, properties = {} }) {
   let attrName;
   const reflectedProperties = {
     connect: (host, key) => {

--- a/src/reflect.js
+++ b/src/reflect.js
@@ -1,5 +1,6 @@
 export default function reflect(value) {
-  const isObject = typeof value === 'object';
+  const type = typeof value;
+  const isObject = type === 'object';
   let attrName;
   const reflectedMethods = {
     connect: (host, key) => {
@@ -10,7 +11,7 @@ export default function reflect(value) {
     },
     observe: (host, val, oldValue) => {
       if (val !== oldValue) {
-        const type = typeof val;
+        // const type = typeof val;
         switch (type) {
           case 'string':
           case 'number':
@@ -37,7 +38,7 @@ export default function reflect(value) {
         value.observe(host, val, oldValue);
       }
     },
-    reflect: true,
+    reflect: type,
   }
  
   if (isObject) {

--- a/src/reflect.js
+++ b/src/reflect.js
@@ -19,13 +19,10 @@ export default function reflect({ type, value, properties }) {
     },
     observe: (host, val, oldValue) => {
       switch (type) {
-        case 'string':
-        case 'number':
         case String:
         case Number:
           host.setAttribute(attrName, val);
           break;
-        case 'boolean':
         case Boolean:
           if (val) {
             host.setAttribute(attrName, '');
@@ -33,8 +30,11 @@ export default function reflect({ type, value, properties }) {
             host.removeAttribute(attrName);
           }
           break;
-        case 'function':
-        case 'object':
+        case Function:
+        case Object:
+        case Array:
+        case Set:
+        case Map:
           debugger;
           break;
         default: break;

--- a/src/reflect.js
+++ b/src/reflect.js
@@ -1,10 +1,15 @@
+import { camelToDash } from './utils';
+
 export default function reflect(value) {
-  const type = typeof value;
+  let type = typeof value;
   const isObject = type === 'object';
   let attrName;
   const reflectedMethods = {
     connect: (host, key) => {
-      attrName = key;
+      attrName = camelToDash(key);
+      if (!host.hasAttribute(attrName)) {
+        host.setAttribute(attrName, value);
+      }
       if (isObject && value.connect) {
         value.connect(host, key);
       }
@@ -12,7 +17,7 @@ export default function reflect(value) {
     observe: (host, val, oldValue) => {
       const oldType = typeof oldValue;
       const newType = typeof val;
-      const type = newType !== 'undefined' ? newType : oldType;
+      type = newType !== 'undefined' ? newType : oldType;
 
       switch (type) {
         case 'string':
@@ -66,10 +71,9 @@ export default function reflect(value) {
     },
     reflect: type,
   }
- 
+
   if (isObject) {
     return Object.assign({}, value, reflectedMethods);
-  } else {
-    return reflectedMethods;
   }
+  return reflectedMethods;
 }

--- a/src/reflect.js
+++ b/src/reflect.js
@@ -1,17 +1,4 @@
-import { camelToDash, coerceValue } from './utils';
-
-function getType(value) {
-  switch (typeof value) {
-    case 'number': return Number;
-    case 'boolean': return Boolean;
-    case 'object':
-      if (Array.isArray(value)) return Array;
-      return Object;
-    case 'function': return Function;
-    case 'string':
-    default: return String;
-  }
-}
+import { camelToDash, coerceToType, getType } from './utils';
 
 export default function reflect(value, properties = {}) {
   let attrName;
@@ -21,7 +8,7 @@ export default function reflect(value, properties = {}) {
       attrName = camelToDash(key);
       const attrValue = host.getAttribute(attrName);
       if (attrValue !== null) {
-        value = coerceValue(attrValue, type);
+        value = coerceToType(attrValue, type);
       }
       if (host[key] === undefined) {
         host[key] = value;
@@ -34,6 +21,9 @@ export default function reflect(value, properties = {}) {
     observe: (host, val, oldValue) => {
       if (val !== oldValue) {
         switch (type) {
+          case null:
+          case undefined:
+            break;
           case Boolean:
             if (val) {
               host.setAttribute(attrName, '');
@@ -46,16 +36,13 @@ export default function reflect(value, properties = {}) {
             host.setAttribute(attrName, JSON.stringify(val));
             break;
           case Function:
-          case Set:
-          case Map:
-            debugger;
             break;
           case String:
           case Number:
           default:
             host.setAttribute(attrName, val);
             break;
-        }  
+        }
       }
 
       if (properties.observe) properties.observe(host, val, oldValue);

--- a/src/reflect.js
+++ b/src/reflect.js
@@ -38,39 +38,12 @@ export default function reflect(value) {
         default: break;
       }
 
-      // console.log('aoeu')
-      // debugger
-
-      // if (val !== oldValue) {
-      //   // const type = typeof val;
-      //   switch (type) {
-      //     case 'string':
-      //     case 'number':
-      //       host.setAttribute(attrName, val);
-      //       break;
-      //     case 'boolean':
-      //       val ? host.setAttribute(attrName, '') : host.removeAttribute(attrName);
-      //       break;
-      //     case 'function':
-      //       debugger;
-      //       // transform = value;
-      //       // value = transform();
-      //       break;
-      //     case 'object':
-      //       debugger;
-      //     //   if (value) Object.freeze(value);
-      //     //   transform = objectTransform;
-      //       break;
-      //     default: break;
-      //   }        
-      // }
-  
       if (isObject && value.observe) {
         value.observe(host, val, oldValue);
       }
     },
     reflect: type,
-  }
+  };
 
   if (isObject) {
     return Object.assign({}, value, reflectedMethods);

--- a/src/reflect.js
+++ b/src/reflect.js
@@ -6,6 +6,7 @@ export default function reflect({ type, value, properties = {} }) {
     connect: (host, key) => {
       attrName = camelToDash(key);
       const attrValue = host.getAttribute(attrName);
+      debugger
       const coercedAttrValue = coerceValue(attrValue, type);
       const currentValue = attrValue === null ? value : coercedAttrValue;
       host[key] = currentValue;
@@ -30,9 +31,12 @@ export default function reflect({ type, value, properties = {} }) {
             host.removeAttribute(attrName);
           }
           break;
+        case Array:
+          debugger
+          host.setAttribute(attrName, JSON.stringify(val));
+          break;
         case Function:
         case Object:
-        case Array:
         case Set:
         case Map:
           debugger;

--- a/src/utils.js
+++ b/src/utils.js
@@ -39,33 +39,6 @@ export function stringifyElement(element) {
 export const IS_IE = 'ActiveXObject' in window;
 export const deferred = Promise.resolve();
 
-export function setAttr(host, key, type, value) {
-  const attr = camelToDash(key);
-  switch (type) {
-    case String:
-    case Number:
-      host.setAttribute(attr, value);
-      break;
-    case Boolean:
-      if (value) {
-        host.setAttribute(attr, '');
-      } else {
-        host.removeAttribute(attr);
-      }
-      break;
-    case Array:
-      host.setAttribute(attr, JSON.stringify(value));
-      break;
-    case Function:
-    case Object:
-    case Set:
-    case Map:
-      debugger;
-      break;
-    default: break;
-  }
-}
-
 export function coerceValue(value, type) {
   switch (type) {
     case String:
@@ -75,14 +48,13 @@ export function coerceValue(value, type) {
       if (value === 'false' || (!value && value !== '')) return false;
       return true;
     case Array:
-      debugger
       if (Array.isArray(value)) {
         return value;
       } else if (typeof value === 'string') {
-        if (/^\[/.test(value) && /\]$/.test(value)) {
+        if (/^\[.*\]$/.test(value)) {
           return JSON.parse(value);
         } else {
-          return value.split(',');
+          return JSON.parse(`[${value}]`);
         }
       } else if (value) {
         return type(value);
@@ -90,6 +62,7 @@ export function coerceValue(value, type) {
         return [];
       }
     case Object:
+      return JSON.parse(value);
     case Function:
       debugger;
       return undefined;

--- a/src/utils.js
+++ b/src/utils.js
@@ -42,13 +42,10 @@ export const deferred = Promise.resolve();
 export function setAttr(host, key, type, value) {
   const attr = camelToDash(key);
   switch (type) {
-    case 'string':
-    case 'number':
     case String:
     case Number:
       host.setAttribute(attr, value);
       break;
-    case 'boolean':
     case Boolean:
       if (value) {
         host.setAttribute(attr, '');
@@ -56,8 +53,13 @@ export function setAttr(host, key, type, value) {
         host.removeAttribute(attr);
       }
       break;
-    case 'function':
-    case 'object':
+    case Array:
+      host.setAttribute(attr, JSON.stringify(value));
+      break;
+    case Function:
+    case Object:
+    case Set:
+    case Map:
       debugger;
       break;
     default: break;
@@ -72,6 +74,21 @@ export function coerceValue(value, type) {
     case Boolean:
       if (value === 'false' || (!value && value !== '')) return false;
       return true;
+    case Array:
+      debugger
+      if (Array.isArray(value)) {
+        return value;
+      } else if (typeof value === 'string') {
+        if (/^\[/.test(value) && /\]$/.test(value)) {
+          return JSON.parse(value);
+        } else {
+          return value.split(',');
+        }
+      } else if (value) {
+        return type(value);
+      } else {
+        return [];
+      }
     case Object:
     case Function:
       debugger;

--- a/src/utils.js
+++ b/src/utils.js
@@ -49,5 +49,4 @@ export function setAttribute(elem, attrName, attrType, value) {
       return null;
     default: elem.setAttribute(attrName, value);
   }
-  return;
-};
+}

--- a/src/utils.js
+++ b/src/utils.js
@@ -39,7 +39,22 @@ export function stringifyElement(element) {
 export const IS_IE = 'ActiveXObject' in window;
 export const deferred = Promise.resolve();
 
-export function coerceValue(value, type) {
+export function getType(value) {
+  switch (typeof value) {
+    case 'undefined': return undefined;
+    case 'number': return Number;
+    case 'boolean': return Boolean;
+    case 'object':
+      if (value === null) return null;
+      if (Array.isArray(value)) return Array;
+      return Object;
+    case 'function': return Function;
+    case 'string':
+    default: return String;
+  }
+}
+
+export function coerceToType(value, type) {
   switch (type) {
     case String:
     case Number:
@@ -48,23 +63,15 @@ export function coerceValue(value, type) {
       if (value === 'false' || (!value && value !== '')) return false;
       return true;
     case Array:
-      if (Array.isArray(value)) {
-        return value;
-      } else if (typeof value === 'string') {
-        if (/^\[.*\]$/.test(value)) {
-          return JSON.parse(value);
-        } else {
-          return JSON.parse(`[${value}]`);
-        }
-      } else if (value) {
-        return type(value);
-      } else {
-        return [];
+      if (Array.isArray(value)) return value;
+      if (typeof value === 'string') {
+        return /^\[.*\]$/.test(value) ? JSON.parse(value) : [];
       }
+      if (value) return type(value);
+      return [];
     case Object:
       return JSON.parse(value);
     case Function:
-      debugger;
       return undefined;
     default: return undefined;
   }

--- a/src/utils.js
+++ b/src/utils.js
@@ -12,6 +12,10 @@ export function pascalToDash(str) {
   return camelToDash(str.replace(/((?!([A-Z]{2}|^))[A-Z])/g, '-$1'));
 }
 
+export function dashToCamel(str) {
+  return str.replace(/-([a-z])/g, c => c[1].toUpperCase());
+}
+
 export function dispatch(host, eventType, options = {}) {
   return host.dispatchEvent(new CustomEvent(eventType, { bubbles: false, ...options }));
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -38,3 +38,16 @@ export function stringifyElement(element) {
 
 export const IS_IE = 'ActiveXObject' in window;
 export const deferred = Promise.resolve();
+
+export function setAttribute(elem, attrName, attrType, value) {
+  switch (attrType) {
+    case 'boolean':
+      return value ? elem.setAttribute(attrName, '') : elem.removeAttribute(attrName);
+    case 'object':
+    case 'function':
+      debugger;
+      return null;
+    default: elem.setAttribute(attrName, value);
+  }
+  return;
+};

--- a/src/utils.js
+++ b/src/utils.js
@@ -39,14 +39,43 @@ export function stringifyElement(element) {
 export const IS_IE = 'ActiveXObject' in window;
 export const deferred = Promise.resolve();
 
-export function setAttribute(elem, attrName, attrType, value) {
-  switch (attrType) {
+export function setAttr(host, key, type, value) {
+  const attr = camelToDash(key);
+  switch (type) {
+    case 'string':
+    case 'number':
+    case String:
+    case Number:
+      host.setAttribute(attr, value);
+      break;
     case 'boolean':
-      return value ? elem.setAttribute(attrName, '') : elem.removeAttribute(attrName);
-    case 'object':
+    case Boolean:
+      if (value) {
+        host.setAttribute(attr, '');
+      } else {
+        host.removeAttribute(attr);
+      }
+      break;
     case 'function':
+    case 'object':
       debugger;
-      return null;
-    default: elem.setAttribute(attrName, value);
+      break;
+    default: break;
+  }
+}
+
+export function coerceValue(value, type) {
+  switch (type) {
+    case String:
+    case Number:
+      return type(value);
+    case Boolean:
+      if (value === 'false' || (!value && value !== '')) return false;
+      return true;
+    case Object:
+    case Function:
+      debugger;
+      return undefined;
+    default: return undefined;
   }
 }

--- a/test/spec/define.js
+++ b/test/spec/define.js
@@ -1,5 +1,6 @@
 import { test, resolveRaf } from '../helpers';
 import define from '../../src/define';
+import reflect from '../../src/reflect';
 import { invalidate } from '../../src/cache';
 
 describe('define:', () => {
@@ -80,6 +81,11 @@ describe('define:', () => {
       five: {
         observe: (...args) => observeSpy(...args),
       },
+      numProp: reflect(6),
+      strProp: reflect('seven'),
+      boolProp: reflect(false),
+      arryProp: reflect([1]),
+      objProp: reflect({ a: 'apple' }),
     });
 
     const tree = test('<test-define-object></test-define-object>');
@@ -154,6 +160,70 @@ describe('define:', () => {
         expect(observeSpy).toHaveBeenCalledTimes(0);
       });
     }));
+
+    it('has observedAttributes', tree((el) => {
+      expect(el.constructor.observedAttributes).toEqual(['num-prop', 'str-prop', 'bool-prop', 'arry-prop', 'obj-prop']);
+    }));
+
+    describe('updates property when an observed attribute changes', () => {
+      it('updates a string property', tree((el) => {
+        el.setAttribute('str-prop', 'new string');
+        return resolveRaf(() => {
+          expect(el.strProp).toBe('new string');
+        });
+      }));
+      it('updates a string property to undefined when attribute is removed', tree((el) => {
+        resolveRaf(() => {
+          el.removeAttribute('str-prop');
+          resolveRaf(() => {
+            expect(el.strProp).toBe(undefined);
+          });
+        });
+      }));
+      it('updates a number property', tree((el) => {
+        el.setAttribute('num-prop', '45');
+        return resolveRaf(() => {
+          expect(el.numProp).toBe(45);
+        });
+      }));
+      it('updates an array property', tree((el) => {
+        el.setAttribute('arry-prop', '[1, 45]');
+        return resolveRaf(() => {
+          expect(el.arryProp).toEqual([1, 45]);
+        });
+      }));
+      it('updates an object property', tree((el) => {
+        el.setAttribute('obj-prop', '{"b": "butter"}');
+        return resolveRaf(() => {
+          expect(el.objProp).toEqual({ b: 'butter' });
+        });
+      }));
+      it('updates a boolean property to true', tree((el) => {
+        el.setAttribute('bool-prop', '');
+        return resolveRaf(() => {
+          expect(el.boolProp).toBe(true);
+        });
+      }));
+      it('updates a boolean property to false', tree((el) => {
+        el.setAttribute('bool-prop', 'false');
+        return resolveRaf(() => {
+          expect(el.boolProp).toBe(false);
+        });
+      }));
+      it('updates a boolean property to false when attribute is removed', tree((el) => {
+        el.removeAttribute('bool-prop');
+        return resolveRaf(() => {
+          expect(el.boolProp).toBe(false);
+        });
+      }));
+      it('updates a boolean property to false', tree((el) => {
+        el.setAttribute('bool-prop', 'false');
+        return resolveRaf(() => {
+          expect(el.boolProp).toBe(false);
+        });
+      }));
+
+    });
   });
 
   describe('for primitive value', () => {

--- a/test/spec/reflect.js
+++ b/test/spec/reflect.js
@@ -37,13 +37,43 @@ describe('reflect:', () => {
 
   const empty = test('<test-reflect></test-reflect>');
 
-  describe('properties are reflected to DOM attributes', () => {
+  describe('observed properties are reflected to DOM attributes', () => {
     it('should have a string attribute', empty(el => resolveRaf(() => {
       expect(el.getAttribute('string-prop')).toBe('value');
     })));
+    it('should remove a string attribute when empty', empty((el) => {
+      el.stringProp = '';
+      resolveRaf(() => {
+        expect(el.getAttribute('string-prop')).toBe(null);
+      });
+    }));
+    it('should remove a string attribute when undefined', empty((el) => {
+      el.stringProp = undefined;
+      resolveRaf(() => {
+        expect(el.getAttribute('string-prop')).toBe(null);
+      });
+    }));
+    it('should remove a string attribute when null', empty((el) => {
+      el.stringProp = null;
+      resolveRaf(() => {
+        expect(el.getAttribute('string-prop')).toBe(null);
+      });
+    }));
     it('should have a number attribute', empty(el => resolveRaf(() => {
       expect(el.getAttribute('number-prop')).toBe('123');
     })));
+    it('should remove a number attribute when undefined', empty((el) => {
+      el.numberProp = undefined;
+      resolveRaf(() => {
+        expect(el.getAttribute('number-prop')).toBe(null);
+      });
+    }));
+    it('should remove a number attribute when null', empty((el) => {
+      el.numberProp = null;
+      resolveRaf(() => {
+        expect(el.getAttribute('number-prop')).toBe(null);
+      });
+    }));
     it('should have a true boolean attribute', empty(el => resolveRaf(() => {
       expect(el.getAttribute('true-bool-prop')).toBe('');
     })));
@@ -56,9 +86,33 @@ describe('reflect:', () => {
     it('should have a stringified array attribute', empty(el => resolveRaf(() => {
       expect(el.getAttribute('array-prop')).toBe('[1,"apple"]');
     })));
+    it('should remove an array attribute when undefined', empty((el) => {
+      el.arrayProp = undefined;
+      resolveRaf(() => {
+        expect(el.getAttribute('array-prop')).toBe(null);
+      });
+    }));
+    it('should remove an array attribute when null', empty((el) => {
+      el.arrayProp = null;
+      resolveRaf(() => {
+        expect(el.getAttribute('array-prop')).toBe(null);
+      });
+    }));
     it('should have a stringified object attribute', empty(el => resolveRaf(() => {
       expect(el.getAttribute('obj-prop')).toBe('{"a":"apple"}');
     })));
+    it('should remove an object attribute when undefined', empty((el) => {
+      el.objProp = undefined;
+      resolveRaf(() => {
+        expect(el.getAttribute('obj-prop')).toBe(null);
+      });
+    }));
+    it('should remove an object attribute when null', empty((el) => {
+      el.objProp = null;
+      resolveRaf(() => {
+        expect(el.getAttribute('obj-prop')).toBe(null);
+      });
+    }));
     it('should not have a null attribute', empty(el => resolveRaf(() => {
       expect(el.getAttribute('null-prop')).toBe(null);
     })));

--- a/test/spec/reflect.js
+++ b/test/spec/reflect.js
@@ -1,0 +1,82 @@
+import { test, resolveRaf } from '../helpers';
+import define from '../../src/define';
+import reflect from '../../src/reflect';
+
+describe('reflect:', () => {
+  const objProp = { a: 'apple' };
+
+  let connectSpy;
+  let observeSpy;
+
+  beforeEach(() => {
+    connectSpy = jasmine.createSpy();
+    observeSpy = jasmine.createSpy();
+  });
+
+  define('test-reflect', {
+    stringProp: reflect('value'),
+    numberProp: reflect(123),
+    falseBoolProp: reflect(false),
+    trueBoolProp: reflect(true),
+    funcProp: reflect(value => ({
+      value,
+    })),
+    arrayProp: reflect([1, 'apple']),
+    objProp: reflect(objProp),
+    nullProp: reflect(null),
+    undefinedProp: reflect(undefined),
+    withLifecycleMethods: reflect(4, {
+      connect: (host, key) => {
+        connectSpy(host, key);
+      },
+      observe: (host, val, lastValue) => {
+        observeSpy(host, val, lastValue);
+      },
+    }),
+  });
+
+  const empty = test('<test-reflect></test-reflect>');
+
+  describe('properties are reflected to DOM attributes', () => {
+    it('should have a string attribute', empty(el => resolveRaf(() => {
+      expect(el.getAttribute('string-prop')).toBe('value');
+    })));
+    it('should have a number attribute', empty(el => resolveRaf(() => {
+      expect(el.getAttribute('number-prop')).toBe('123');
+    })));
+    it('should have a true boolean attribute', empty(el => resolveRaf(() => {
+      expect(el.getAttribute('true-bool-prop')).toBe('');
+    })));
+    it('should not have a false boolean attribute', empty(el => resolveRaf(() => {
+      expect(el.getAttribute('false-bool-prop')).toBe(null);
+    })));
+    it('should not have a function attribute', empty(el => resolveRaf(() => {
+      expect(el.getAttribute('func-prop')).toBe(null);
+    })));
+    it('should have a stringified array attribute', empty(el => resolveRaf(() => {
+      expect(el.getAttribute('array-prop')).toBe('[1,"apple"]');
+    })));
+    it('should have a stringified object attribute', empty(el => resolveRaf(() => {
+      expect(el.getAttribute('obj-prop')).toBe('{"a":"apple"}');
+    })));
+    it('should not have a null attribute', empty(el => resolveRaf(() => {
+      expect(el.getAttribute('null-prop')).toBe(null);
+    })));
+    it('should not have an undefined attribute', empty(el => resolveRaf(() => {
+      expect(el.getAttribute('undefined-prop')).toBe(null);
+    })));
+  });
+
+  describe('reflected property with lifecycle methods', () => {
+    it('should call user defined lifecycle methods method', empty((el) => {
+      expect(connectSpy).toHaveBeenCalledTimes(1);
+
+      resolveRaf(() => {
+        el.numberWithMethods = 5;
+        resolveRaf(() => {
+          expect(observeSpy).toHaveBeenCalledTimes(1);
+        });
+      });
+    }));
+  });
+});

--- a/test/spec/utils.js
+++ b/test/spec/utils.js
@@ -1,0 +1,118 @@
+import { dashToCamel, getType, coerceToType } from '../../src/utils';
+
+describe('dashToCamel', () => {
+  it('converts dashed string to camel case', () => {
+    expect(dashToCamel('foo-bar-baz')).toBe('fooBarBaz');
+  });
+  it('passes un-dashed string through unchanged', () => {
+    expect(dashToCamel('fooBarBaz')).toBe('fooBarBaz');
+  });
+});
+
+describe('getType', () => {
+  describe('Number', () => {
+    it('should return Number for a positive integer', () => {
+      expect(getType(1)).toBe(Number);
+    });
+    it('should return Number for zero', () => {
+      expect(getType(0)).toBe(Number);
+    });
+    it('should return Number for a negative integer', () => {
+      expect(getType(-1)).toBe(Number);
+    });
+    it('should return Number for a float', () => {
+      expect(getType(1.1)).toBe(Number);
+    });
+  });
+
+  describe('Boolean', () => {
+    it('should return Boolean for true', () => {
+      expect(getType(true)).toBe(Boolean);
+    });
+    it('should return Boolean for false', () => {
+      expect(getType(false)).toBe(Boolean);
+    });
+  });
+
+  describe('Array', () => {
+    it('should return Array for an array', () => {
+      expect(getType([])).toBe(Array);
+    });
+  });
+
+  describe('Undefined', () => {
+    it('should return undefined for an undefined object', () => {
+      expect(getType(undefined)).toBe(undefined);
+    });
+  });
+
+  describe('Null', () => {
+    it('should return null for a null object', () => {
+      expect(getType(null)).toBe(null);
+    });
+  });
+
+  describe('Object', () => {
+    it('should return Object for an object', () => {
+      expect(getType({})).toBe(Object);
+    });
+  });
+
+  describe('Function', () => {
+    it('should return Function for a function', () => {
+      expect(getType(() => 'test')).toBe(Function);
+    });
+  });
+});
+
+describe('coerceToType', () => {
+  describe('Number', () => {
+    it('should return a Number', () => {
+      expect(coerceToType(4, Number)).toBe(4);
+      expect(coerceToType('4', Number)).toBe(4);
+    });
+  });
+
+  describe('String', () => {
+    it('should return a String', () => {
+      expect(coerceToType(4, String)).toBe('4');
+      expect(coerceToType('4', String)).toBe('4');
+    })
+  });
+
+  describe('Boolean', () => {
+    it('should return true', () => {
+      expect(coerceToType('', Boolean)).toBe(true);
+      expect(coerceToType('true', Boolean)).toBe(true);
+      expect(coerceToType('stuff', Boolean)).toBe(true);
+    });
+
+    it('should return false', () => {
+      expect(coerceToType(null, Boolean)).toBe(false);
+      expect(coerceToType(undefined, Boolean)).toBe(false);
+      expect(coerceToType('false', Boolean)).toBe(false);
+    });
+  });
+
+  describe('Array', () => {
+    it('should return an Array', () => {
+      expect(coerceToType([1, 2], Array)).toEqual([1, 2]);
+      expect(coerceToType('[1, 2]', Array)).toEqual([1, 2]);
+      expect(coerceToType('1,2', Array)).toEqual([]);
+      expect(coerceToType('stuff', Array)).toEqual([]);
+    });
+  });
+
+  describe('Object', () => {
+    it('should return an Object', () => {
+      expect(coerceToType('{"a": "apple"}', Object)).toEqual({a: 'apple'});
+    });
+  });
+
+  describe('Function', () => {
+    it('should return undefined', () => {
+      expect(coerceToType(() => 'test', Function)).toBe(undefined);
+    });
+  });
+
+});


### PR DESCRIPTION
I've really enjoyed using hybrids for web-component creation, however my specific use case is such that I need to be able to reflect property changes to DOM attributes (and vice-versa), which is currently something that hybrids does not do.

To enable this functionality I've created a custom `reflect` factory, however in order for it to monitor attribute changes and reflect those changes back to properties I've needed to make a few small modifications to hybrids itself.

I'd love to see this functionality added to core!