### PR TITLE
Fix cache observer

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "author": "Dominik Lubański <dominik.lubanski@gmail.com>",
   "repository": "https://github.com/hybridsjs/hybrids",
   "scripts": {
-    "dev": "karma start",
+    "dev": "karma start --browsers ChromeHeadless",
     "dev:coverage": "rm -rf ./coverage && NODE_ENV=coverage npm run dev",
     "test": "karma start --single-run",
     "test:coverage": "rm -rf ./coverage && NODE_ENV=coverage npm run test -- --browsers ChromeHeadless",

--- a/src/define.js
+++ b/src/define.js
@@ -43,23 +43,16 @@ function compile(Hybrid, descriptors) {
       configurable: process.env.NODE_ENV !== 'production',
     });
 
-    if (config.connect) {
-      Hybrid.callbacks.push((host) => config.connect(host, key, () => {
-        cache.invalidate(host, key);
-      }));
+    if (config.observe) {
+      Hybrid.callbacks.push(
+        (host) => cache.observe(host, key, config.get, config.observe),
+      );
     }
 
-    if (config.observe) {
-      Hybrid.callbacks.push((host) => {
-        let lastValue;
-        return cache.observe(host, key, () => {
-          const value = host[key];
-          if (value !== lastValue) {
-            config.observe(host, value, lastValue);
-            lastValue = value;
-          }
-        });
-      });
+    if (config.connect) {
+      Hybrid.callbacks.push(
+        (host) => config.connect(host, key, () => { cache.invalidate(host, key); }),
+      );
     }
   });
 }


### PR DESCRIPTION
When contexts are created for observing value changes in complex dependency tree they might not be cleaned properly when the element is disconnected from the DOM. This PR fixes this by flattening deps structure with `contextStack` instead of deep tree of dependencies.