### PR TITLE
feat: TypeScript definitions

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -32,5 +32,6 @@
 ## Misc
 
 - [Utils](misc/utils.md)
+- [Typescript](misc/typescript.md)
 - [API Reference](misc/api-reference.md)
 - [Change Log](../CHANGELOG.md)

--- a/docs/misc/README.md
+++ b/docs/misc/README.md
@@ -1,5 +1,6 @@
 # Misc
 
 - [Utils](./utils.md)
+- [TypeScript](./typescript.md)
 - [API Reference](./api-reference.md)
 - [Change Log](../../CHANGELOG.md)

--- a/docs/misc/typescript.md
+++ b/docs/misc/typescript.md
@@ -1,0 +1,51 @@
+# TypeScript
+
+The library supports [TypeScript](https://www.typescriptlang.org/) out of the box by the types from `types/index.d.ts` file. The web component definition should contain an interface extending `HTMLElement` and a map of descriptors using `Hybrids<E>` type (where generic type `E` is the defined interface).
+
+A counter component from the Getting Started section can be written in TS with the following code:
+
+```typescript
+// simple-counter.ts
+
+import { define, html, Hybrids } from 'hybrids';
+
+interface SimpleCounter extends HTMLElement {
+  count: number;
+}
+
+export function increaseCount(host: SimpleCounter) {
+  host.count += 1;
+}
+
+export const SimpleCounter: Hybrids<SimpleCounter> = {
+  count: 0,
+  render: ({ count }) => html<SimpleCounter>`
+    <button onclick="${increaseCount}">
+      Count: ${count}
+    </button>
+  `,
+};
+
+define('simple-counter', SimpleCounter);
+```
+
+The `Hybrids<E>` type has built-in support for the [descriptors structure](../core-concepts/descriptors.md) and all of [translation](../core-concepts/translation.md) rules. It also prevents from defining properties not declared in the element interface.
+
+All public APIs support generic type `<E>` for providing additional information from the defined interface. For example, the factories run before TS can check the structure (the result of the function is passed to the component definition, not a function reference), so you have to pass your component interface to the function explicitly:
+
+```typescript
+import { property, Hybrids } from 'hybrids';
+
+interface MyElement extends HTMLElement {
+ value: boolean;
+}
+
+const MyElement: Hybrids<MyElement> = {
+ value: property<MyElement>(false, (host) => {
+   // TS knows that the `host` is MyElement, which has `value` property
+   console.log(host.value);
+ }),
+};
+```
+
+Provided types are part of the public API, so any changes will follow semantic versioning of the library. For more depth understanding, read the `types/index.d.ts` source file.

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "lib/index.js",
   "module": "esm/index.js",
   "jsnext:main": "esm/index.js",
+  "types": "types/index.d.ts",
   "author": "Dominik Lubański <dominik.lubanski@gmail.com>",
   "repository": "https://github.com/hybridsjs/hybrids",
   "homepage": "https://hybrids.js.org",

--- a/src/render.js
+++ b/src/render.js
@@ -1,6 +1,6 @@
-export default function render(get, customOptions = {}) {
-  if (typeof get !== 'function') {
-    throw TypeError(`The first argument must be a function: ${typeof get}`);
+export default function render(fn, customOptions = {}) {
+  if (typeof fn !== 'function') {
+    throw TypeError(`The first argument must be a function: ${typeof fn}`);
   }
 
   const options = { shadowRoot: true, ...customOptions };
@@ -12,9 +12,9 @@ export default function render(get, customOptions = {}) {
 
   return {
     get(host) {
-      const fn = get(host);
+      const update = fn(host);
       return function flush() {
-        fn(host, options.shadowRoot ? host.shadowRoot : host);
+        update(host, options.shadowRoot ? host.shadowRoot : host);
       };
     },
     connect(host) {
@@ -22,8 +22,8 @@ export default function render(get, customOptions = {}) {
         host.attachShadow(shadowRootInit);
       }
     },
-    observe(host, fn) {
-      fn();
+    observe(host, flush) {
+      flush();
     },
   };
 }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,94 @@
+// tslint:disable-next-line:export-just-namespace
+export = hybrids;
+export as namespace hybrids;
+
+declare namespace hybrids {
+  interface Descriptor<E extends HTMLElement> {
+    get?(host: E, lastValue: any): any;
+    set?(host: E, value: any, lastValue: any): any;
+    connect?(host: E, key: string, invalidate: Function): Function;
+    observe?(host: E, value: any, lastValue: any): void;
+  }
+
+  type Property<E extends HTMLElement> =
+    | string
+    | number
+    | boolean
+    | null
+    | undefined
+    | any[]
+    | Descriptor<E>;
+
+  interface UpdateFunction<E extends HTMLElement> {
+    (host: E, target?: HTMLElement): void;
+  }
+
+  interface RenderFunction<E extends HTMLElement> {
+    (host: E) : UpdateFunction<E>;
+  }
+
+  type Hybrids<E extends HTMLElement> =
+   { render?: RenderFunction<E> | Property<E> }
+   & { [property in keyof E]?: Property<E> | Descriptor<E>['get'] }
+
+  interface MapOfHybridsOrConstructors {
+    [tagName: string]: Hybrids<any> | typeof HTMLElement,
+  }
+
+  type MapOfConstructors<T> = {
+    [tagName in keyof T]: typeof HTMLElement;
+  }
+
+  interface HybridElement<E extends HTMLElement> {
+    new(): E;
+    prototype: E;
+  }
+
+  /* Define */
+
+  function define<E extends HTMLElement>(tagName: string, hybridsOrConstructor: Hybrids<E> | typeof HTMLElement): HybridElement<E>;
+  function define(mapOfHybridsOrConstructors: MapOfHybridsOrConstructors): MapOfConstructors<typeof mapOfHybridsOrConstructors>;
+
+  /* Factories */
+
+  function property<E extends HTMLElement>(value: any, connect?: Descriptor<E>['connect']): Descriptor<E>;
+  function parent<E extends HTMLElement>(hybridsOrFn: Hybrids<E> | ((hybrids: Hybrids<E>) => boolean)): Descriptor<E>;
+  function children<E extends HTMLElement>(hybridsOrFn: (Hybrids<E> | ((hybrids: Hybrids<E>) => boolean)), options? : { deep?: boolean, nested?: boolean }): Descriptor<E>;
+  function render<E extends HTMLElement>(fn: RenderFunction<E>, customOptions?: { shadowRoot?: boolean | object }): Descriptor<E>;
+
+  /* Template Engine */
+
+  interface UpdateFunctionWithMethods<E extends HTMLElement> extends UpdateFunction<E> {
+    define: (elements: MapOfHybridsOrConstructors) => this;
+    key: (id: any) => this;
+    style: (...styles: string[]) => this;
+  }
+
+  interface EventHandler<E extends HTMLElement> {
+    (host: E, event?: Event) : any;
+  }
+
+  type TemplateValue<E extends HTMLElement> =
+    | string
+    | number
+    | boolean
+    | null
+    | undefined
+    | UpdateFunction<E>;
+
+  type TemplateExpression<E extends HTMLElement> = TemplateValue<E> | TemplateValue<E>[] | EventHandler<E>;
+
+  namespace html {
+    function set<E extends HTMLElement>(propertyName: keyof E, value?: any): EventHandler<E>;
+    function resolve<E extends HTMLElement>(promise: Promise<UpdateFunction<E>>, placeholder?: UpdateFunction<E>, delay?: number): UpdateFunction<E>;
+  }
+
+  function html<E extends HTMLElement>(parts: TemplateStringsArray, ...args: TemplateExpression<E>[]): UpdateFunctionWithMethods<E>;
+
+  namespace svg {
+    function set<E extends HTMLElement>(propertyName: keyof E, value?: any): EventHandler<E>;
+    function resolve<E extends HTMLElement>(promise: Promise<UpdateFunction<E>>, placeholder?: UpdateFunction<E>, delay?: number) : UpdateFunction<E>;
+  }
+
+  function svg<E extends HTMLElement>(parts: TemplateStringsArray, ...args: TemplateExpression<E>[]): UpdateFunctionWithMethods<E>;
+}


### PR DESCRIPTION
This PR adds TypeScript definitions file (`types/index.d.ts`).  I think it covers almost all cases. At first, I tried to avoid passing generic types, and use descriptors to determine the type, but I think it is not possible.

From now in TS the original example from homepage of the docs can be written as follows:

```typescript
import { define, html, Hybrids } from 'hybrids';

interface SimpleCounter extends HTMLElement {
  count: number;
}

export function increaseCount(host: SimpleCounter) {
  host.count += 1;
}

export const SimpleCounter: Hybrids<SimpleCounter> = {
  count: 0,
  render: ({ count }) => html`
    <button onclick="${increaseCount}">
      Count: ${count}
    </button>
  `,
};

define('simple-counter', SimpleCounter);
```

What we have from types here:

* Interface of the definition have to extend `HTMLElement`
* `render` function arguments knows, that `host` is `SimpleCounter`
* `html` accepts only in expression functions, which are compatible with `UpdateFunction` or `EventHandler` types
* You can't define a property, which is not declared in its interface

However, I think it is not possible to tell TS that call to `html` could use passed generic type (`SimpleCounter`), so in the above example `increaseCount()` first argument must be compatible with `HTMLElement`, not the `SimpleCounter`. If you want that, the generic type must be passed to `html` function:

```typescript
{
  render: ({ count }) => html<SimpleCounter>`
    <button onclick="${increaseCount}">
      Count: ${count}
    </button>
  `,
}
```

Even though `RenderFunction` definition takes generic type from the definition. Is there any way to do this? I suppose that the body of the function can be anything, so TS doesn't use this information...

There is also one missing thing with `define({ MyElement, OtherElement })` call. If you define your element as a type of `Hybrids<MyElement>` I don't know how to take out that generic type and use it to built a map of HTMLElement constructors as a result of the function, which uses that additional properties. I could use one generic type, but than it was taking always generic type from the first key... So, for now, it uses only the `HTMLElement` interface and loses additional information in that usage of the `define()` function.

This is what I tried to do:

```typescript
function define<E>(
  mapOfHybridsOrConstructors: { [tagName: string]: Hybrids<E> | typeof HTMLElement }
): { [tagName in keyof typeof mapOfHybridsOrConstructors]: HybridElement<E> };
```

Then `E` is taken from only of the first definitions and used for all results...