### PR TITLE
fix(render): allow update before schedule; render call should return target

### DIFF
--- a/docs/built-in-factories/render.md
+++ b/docs/built-in-factories/render.md
@@ -11,7 +11,7 @@ render(fn: Function, options: Object = { shadowRoot: true }): Object
     * `{ shadowRoot: false }` - sets `target` argument as `host`,
     * `{ shadowRoot: { extraOption: true, ... } }` - initializes Shadow DOM with passed options for `attachShadow()` method
 * **returns**:
-  * hybrid property descriptor, which resolves to a function
+  * hybrid property descriptor, which resolves to a function (when called manually, it returns `target`)
 
 ```javascript
 import { render } from 'hybrids';
@@ -25,45 +25,34 @@ export const MyElement = {
 };
 ```
 
-Render factory creates and updates the DOM structure of your custom element. It works out of the box with built-in [template engine](../template-engine/introduction.md), but the passed `fn` function may use any external UI library, that renders DOM.
+Render factory creates and updates the DOM structure of your custom element. It works out of the box with built-in [template engine](../template-engine/introduction.md), but the passed `fn` function may use any external UI library that renders DOM.
 
 👆 [Click and play with `render` factory using  `React` library on ⚡StackBlitz](https://stackblitz.com/edit/hybrids-react-counter?file=react-counter.js)
 
-Render factory trigger update of the DOM by the `observe` method of the descriptor. It means that an update is scheduled with the internal queue and executed in the next animation frame. The passed `fn` is always called for the first time and when related properties change.
+Render factory trigger the update of the DOM by the `observe` method of the descriptor. It means that an update is scheduled with the internal queue and executed in the next animation frame. The passed `fn` is always called for the first time and when related properties change.
 
-If you use render factory for wrapping other UI libraries remember to access required properties from the `host` synchronously in the body of `fn` function (only then cache mechanism can save dependencies for the update). Otherwise, your function might be called only once.
+If you use render factory for wrapping other UI libraries, remember to access required properties from the `host` synchronously in the body of `fn` function (only then cache mechanism can save dependencies for the update). Otherwise, your function might be called only once.
 
 👆 [Click and play with `render` factory using  `lit-html` library on ⚡StackBlitz](https://stackblitz.com/edit/hybrids-lit-html-counter?file=lit-counter.js)
 
-### Translation
+## Translation
 
-The `render` key of the property is not mandatory. However, the first rule of the [translation](../core-concepts/translation.md) makes possible to pass `fn` function as a `render` property to use render factory:
+The `render` key of the property is not mandatory. However, the first rule of the [translation](../core-concepts/translation.md) makes possible to set `fn` function as a `render` property to use the render factory implicitly:
 
 ```javascript
 import { html } from 'hybrids';
 
 const MyElement = {
   value: 1,
-  render: ({ value }) => html`<div>${value}</div>`,
+  render: ({ value }) => html`<div>${value}</div>`, // It equals `render: render(({ value }) => ...)`
 };
 ```
-
-## Manual Update
-
-It is possible to trigger an update by calling property manually on the element instance:
-
-```javascript
-const myElement = document.getElementsByTagName('my-element')[0];
-myElement.render();
-```
-
-Property defined with `render` factory uses the same cache mechanism like other properties. The update process calls `fn` only if related properties have changed.
 
 ## Shadow DOM
 
 The factory by default uses [Shadow DOM](https://developer.mozilla.org/docs/Web/Web_Components/Using_shadow_DOM) as a `target`, which is created synchronously in `connect` callback. It is expected behavior, so usually you can omit `options` object and use [translation](../core-concepts/translation.md) rule for the render factory.
 
-Although, If your element does not require [style encapsulation](https://developers.google.com/web/fundamentals/web-components/shadowdom#styling) and [children distribution](https://developers.google.com/web/fundamentals/web-components/shadowdom#composition_slot) (`<slot>` element can be used only inside of the `shadowRoot`) you can disable Shadow DOM in the `options` object. Then, `target` argument of the update function become a `host`. In the result, your template will replace children content of the custom element (in Light DOM).
+Although, If your element does not require [style encapsulation](https://developers.google.com/web/fundamentals/web-components/shadowdom#styling) and [children distribution](https://developers.google.com/web/fundamentals/web-components/shadowdom#composition_slot) (`<slot>` element can be used only inside of the `shadowRoot`) you can disable Shadow DOM in the `options` object. Then, `target` argument of the update function becomes a `host`. As a result, your template will replace children's content of the custom element (in Light DOM).
 
 Keep in mind that the `options` can be passed only with `render(fn, options)` factory function called explicitly:
 
@@ -79,9 +68,71 @@ const MyElement = {
 };
 ```
 
+## Manual Update
+
+It is possible to trigger an update by calling property manually on the element instance:
+
+```javascript
+const myElement = document.getElementsByTagName('my-element')[0];
+const target = myElement.render();
+
+console.log(target); // returns `host.shadowRoot` or `host` element according to the `shadowRoot` option
+```
+
+Property defined with `render` factory uses the same cache mechanism like other properties. The update process calls `fn` only if related properties have changed. However, calling `myElement.render()` always invoke the result of the `fn()` (the update function).
+
+## Reference Internals
+
+If your element should expose internal parts of the content as a public API, you can use `render()` to set custom property as an internal DOM element from the rendered content. Using `render` in the getter of the defined property ensures that render process is called and it adds it to the dependencies of the property. The result of the call gives us a `target` element, so you don't have to relay on the render configuration (it might be the `shadowRoot` as well as the `host` element - but both has `querySelector` API):
+
+```javascript
+const MyCanvasElement = {
+  canvas: ({ render }) => {
+    const target = render();
+    return target.querySelector('canvas');
+  },
+  width: '100%',
+  height: '100%',
+  render: ({ width, height }) => html`
+    <style>
+      :host { ... }
+    </style>
+    <canvas style="${{ width, height }}"></canvas>
+  `,
+}
+```
+
+The `canvas` property from the above example will always reference the proper element from the shadowRoot. Even though the render process is asynchronous, if the user gets `canvas` before the first scheduled render, it will return the element interface because of calling `render()` manually. Moreover, the cache mechanism ensures that the `canvas` property result is cached. It is recalculated only when dependencies of the render property change. This allows creating dynamic selectors, which returns different results depends on the render dependencies.
+
+If you have more references to internal elements, you can create simple factory and use it multiple times:
+
+```javascript
+function ref(query) {
+  return ({ render }) => {
+    if (typeof render === 'function') {
+      const target = render();
+      return target.querySelector(query);
+    }
+
+    return null;
+  };
+}
+
+const MyElement = {
+  canvas: ref('canvas'),
+  wrapper: ref('div#wrapper'),
+  render: ({ ... }) => html`
+    <canvas></canvas>
+    <div id="wrapper">
+      ...
+    </div>
+  `,
+}
+```
+
 ## Unit Testing
 
-Because of the asynchronous update mechanism with threshold, it might be tricky to test if the custom element instance renders correctly. However, you can create your unit tests based on the definition itself.
+Because of the asynchronous update mechanism, it might be tricky to test if the custom element instance renders correctly. However, you can create your unit tests based on the definition itself.
 
 The render key is usually a function, which returns the update function. It can be called synchronously with mocked host and arbitrary target element (for example `<div>` element):
 

--- a/src/render.js
+++ b/src/render.js
@@ -13,14 +13,17 @@ export default function render(fn, customOptions = {}) {
   return {
     get(host) {
       const update = fn(host);
-      return function flush() {
-        update(host, options.shadowRoot ? host.shadowRoot : host);
-      };
-    },
-    connect(host) {
-      if (options.shadowRoot && !host.shadowRoot) {
-        host.attachShadow(shadowRootInit);
+      let target = host;
+
+      if (options.shadowRoot) {
+        if (!host.shadowRoot) host.attachShadow(shadowRootInit);
+        target = host.shadowRoot;
       }
+
+      return function flush() {
+        update(host, target);
+        return target;
+      };
     },
     observe(host, flush) {
       flush();

--- a/test/spec/render.js
+++ b/test/spec/render.js
@@ -35,7 +35,9 @@ describe('render:', () => {
   })));
 
   it('renders content on direct call', tree((el) => {
-    el.render();
+    const target = el.render();
+
+    expect(target).toBe(el.shadowRoot);
     expect(el.shadowRoot.children[0].textContent).toBe('0');
   }));
 
@@ -114,9 +116,9 @@ describe('render:', () => {
 
       test(`
         <test-render-custom-shadow></test-render-custom-shadow>
-      `)(() => {
+      `)(() => resolveRaf(() => {
         expect(spy).toHaveBeenCalledWith({ mode: 'open', delegatesFocus: true });
-      })(done);
+      }))(done);
     });
   });
 });


### PR DESCRIPTION
This PR changes two internal parts of the render factory and is related to #86 issue.

* Moves `attachShadow` from `connect()` to `get()` method - this allows calling `el.render()` before the property is connected. It might happen if in other property depends on render and it is called in `observe` or `connect` method
* Returns target from `flush()` - for direct call to update function - `el.render()` - this fixes possibility to create refs to internal parts as a public API of the element