### PR TITLE
Transform boolean attribute values to preserve reasonable values.

### DIFF
--- a/docs/built-in-factories/property.md
+++ b/docs/built-in-factories/property.md
@@ -41,10 +41,12 @@ The type of `defaultValue` is used to detect the transform function. For example
 
 * `string` -> `String(value)`
 * `number` -> `Number(value)`
-* `boolean` -> `Boolean(value)`
+* `boolean` -> `JSON.parse('true' | 'false') || Boolean(value)`
 * `function` -> `defaultValue(value)`
 * `object` -> `Object.freeze(value)`
 * `undefined` -> `value`
+
+Boolean values are parsed with JSON.parse if their lowercase values are either 'true' or 'false'. Otherwise, the `Boolean` constructor is used.
 
 Object values are frozen to prevent mutation of their properties, which does not invalidate cached value. Moreover, `defaultValue` is shared between custom element instances, so any of them should not change it.
 

--- a/src/property.js
+++ b/src/property.js
@@ -10,7 +10,7 @@ const objectTransform = (value) => {
 };
 
 const booleanTransform = (value) => {
-  value = value.toLowerCase();
+  value = typeof value === 'string' ? value.toLowerCase() : value;
   if (value === 'true' || value === 'false') {
     return JSON.parse(value);
   }

--- a/src/property.js
+++ b/src/property.js
@@ -9,6 +9,14 @@ const objectTransform = (value) => {
   return value && Object.freeze(value);
 };
 
+const booleanTransform = (value) => {
+  value = value.toLowerCase();
+  if (value === 'true' || value === 'false') {
+    return JSON.parse(value);
+  }
+  return Boolean(value);
+};
+
 export default function property(value, connect) {
   const type = typeof value;
   let transform = defaultTransform;
@@ -21,7 +29,7 @@ export default function property(value, connect) {
       transform = Number;
       break;
     case 'boolean':
-      transform = Boolean;
+      transform = booleanTransform;
       break;
     case 'function':
       transform = value;

--- a/test/spec/property.js
+++ b/test/spec/property.js
@@ -102,6 +102,20 @@ describe('property:', () => {
       el.boolProp = '';
       expect(el.boolProp).toBe(false);
     }));
+
+    it('transforms the boolean prop to the correct attribute value', (done) => {
+      define('test-true-boolean', {
+        boolProp: property(true),
+      });
+
+      const boolTree = test(`
+        <test-true-boolean boolProp="false"></test-true-boolean>
+      `);
+
+      boolTree((el) => {
+        expect(el.boolProp).toBe(false);
+      })(done);
+    });
   });
 
   describe('function type', () => {

--- a/test/spec/property.js
+++ b/test/spec/property.js
@@ -109,7 +109,7 @@ describe('property:', () => {
       });
 
       const boolTree = test(`
-        <test-true-boolean boolProp="false"></test-true-boolean>
+        <test-true-boolean bool-prop="false"></test-true-boolean>
       `);
 
       boolTree((el) => {


### PR DESCRIPTION
In the case of a Hybrids element property with a default value of 'true', any attempt to make the property false by passing an attribute value of 'false' failed.

Instead of passing boolean attribute values through the Boolean constructor, this change passes 'true' and 'false' values through JSON.parse() to avoid confusing during attribute assignment to properties.

If you'd prefer a different approach than the one described in this PR or have some workaround in mind, by all means, feel free to reject it. 😄 

You should know that I had some trouble getting the tests to run on my machine and so I've made the modifications to the spec file blindly. If all looks good, you should at least pull the branch down and run the test in case I've fat-fingered something there.

---

Related Issue: #92