### PR TITLE
made contexts default to new Set()

### DIFF
--- a/src/cache.js
+++ b/src/cache.js
@@ -16,7 +16,7 @@ export function getEntry(target, key) {
       target,
       key,
       value: undefined,
-      contexts: undefined,
+      contexts: new Set(),
       deps: undefined,
       state: 0,
       checksum: 0,
@@ -41,7 +41,7 @@ function calculateChecksum(entry) {
 
 function dispatchDeep(entry) {
   if (entry.observed) emitter.dispatch(entry);
-  if (entry.contexts) entry.contexts.forEach(dispatchDeep);
+  entry.contexts.forEach(dispatchDeep);
 }
 
 const contextStack = new Set();


### PR DESCRIPTION
This fixes a bug I was having. "contexts" was undefined upon initialization, and while setting certain properties of the hybrid model, the cache function was trying to delete a value out of the contexts value (which was undefined). very small code change. 