### PR TITLE
feat(html): scoped elements

### DIFF
--- a/src/template/core.js
+++ b/src/template/core.js
@@ -57,8 +57,17 @@ function applyShadyCSS(template, tagName) {
   }, template);
 }
 
-function createSignature(parts, styles) {
+function createSignature(parts, styles, scopedElements) {
   let signature = parts.reduce((acc, part, index) => {
+    if (scopedElements) {
+      scopedElements.forEach(({ rawName, finalName }) => {
+        part = part.replace(new RegExp(`<${rawName}>`, "g"), `<${finalName}>`);
+        part = part.replace(
+          new RegExp(`</${rawName}>`, "g"),
+          `</${finalName}>`,
+        );
+      });
+    }
     if (index === 0) {
       return part;
     }
@@ -203,11 +212,11 @@ function beautifyTemplateLog(input, index) {
   return `${output}`;
 }
 
-export function compileTemplate(rawParts, isSVG, styles) {
+export function compileTemplate(rawParts, isSVG, styles, scopedElements) {
   const template = document.createElement("template");
   const parts = [];
 
-  let signature = createSignature(rawParts, styles);
+  let signature = createSignature(rawParts, styles, scopedElements);
   if (isSVG) signature = `<svg>${signature}</svg>`;
 
   /* istanbul ignore if */

--- a/test/spec/html.js
+++ b/test/spec/html.js
@@ -903,6 +903,25 @@ describe("html:", () => {
     });
   });
 
+  describe("scope method", () => {
+    it("replaces and defines scope element", () => {
+      const ScopedElement = {
+        value: "test",
+      };
+
+      const render = html`
+        <scoped-element></scoped-element>
+      `.scope({ ScopedElement });
+
+      render(fragment);
+
+      expect(fragment.children[0].value).toBe("test");
+      expect(fragment.children[0].tagName.toLowerCase()).not.toBe(
+        "scoped-element",
+      );
+    });
+  });
+
   describe("style method", () => {
     const render = html`
       <div>content</div>


### PR DESCRIPTION
It's rather a naive implementation of the scoped elements definition to check if it is possible to implement similar to https://open-wc.org/scoped-elements/ in hybrids.

```javascript
import { html } from "hybrids";
import ScopedElement from "./ScopedElement";

const MyElement = {
  render: () => html`
    <scoped-element></scoped-element>
  `.scope({ ScopedElement }),
};
```

It's naive because of simple replacement of the element's names - it should be smarter, as that substring might be used in different context inside of the template string.