### PR TITLE
feat(define): Hybrid constructor without definition in the registry

### DIFF
--- a/docs/core-concepts/definition.md
+++ b/docs/core-concepts/definition.md
@@ -4,7 +4,7 @@ To define custom element use `define` function. It takes a tag name and plain ob
 
 To simplify using external custom elements with those created by the library, you can pass `constructor` instead of a plain object. Then `define` works exactly the same as the `customElements.define()` method.
 
-### Single Element
+## Single Element
 
 ```javascript
 import { define } from 'hybrids';
@@ -18,16 +18,28 @@ define('my-element', MyElement);
 ```
 
 ```typescript
-define(tagName: string, descriptorsOrConstructor: Object | Function): Wrapper
+define(tagName: string | null, descriptorsOrConstructor: Object | Function): Wrapper
 ```
 
 * **arguments**:
-  * `tagName` - a custom element tag name,
-  * `descriptorsOrConstructor` - an object with a map of hybrid property descriptors or constructor
-* **returns**: 
+  * `tagName` - a custom element tag name or `null`,
+  * `descriptorsOrConstructor` - an object with a map of hybrid property descriptors or a constructor
+* **returns**:
   * `Wrapper` - custom element constructor (extends `HTMLElement`)
 
-### Map of Elements
+If the `tagName` is set to `null`, the `define` function only generates a class constructor without registering it in the global custom elements registry. This mode might be helpful for creating a custom element for external usage without dependency on tag name, and where the `hybrids` library is not used directly.
+
+```javascript
+// in the package
+const MyElement = { ... };
+export default define(null, MyElement);
+
+// in the client
+import { MyElement } from "components-library";
+customElements.define("my-super-element", MyElement);
+```
+
+## Map of Elements
 
 ```javascript
 import { define } from 'hybrids';

--- a/test/spec/define.js
+++ b/test/spec/define.js
@@ -11,6 +11,22 @@ describe("define:", () => {
     expect(CustomElement.name).toBe("test-define-custom-element");
   });
 
+  it("returns the constructor without defining in the registry", () => {
+    const MyElement = {
+      value: "test",
+    };
+
+    const Constructor = define(null, MyElement);
+
+    expect(Constructor.prototype.value).toBeDefined();
+    expect(define(null, MyElement)).not.toBe(Constructor);
+
+    customElements.define("test-define-from-constructor", Constructor);
+    const el = document.createElement("test-define-from-constructor");
+
+    expect(el.value).toBe("test");
+  });
+
   describe("for map argument", () => {
     it("defines hybrids", done => {
       const testHtmlDefine = { value: "test" };

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -46,7 +46,7 @@ declare namespace hybrids {
 
   /* Define */
 
-  function define<E extends HTMLElement>(tagName: string, hybridsOrConstructor: Hybrids<E> | typeof HTMLElement): HybridElement<E>;
+  function define<E extends HTMLElement>(tagName: string | null, hybridsOrConstructor: Hybrids<E> | typeof HTMLElement): HybridElement<E>;
   function define(mapOfHybridsOrConstructors: MapOfHybridsOrConstructors): MapOfConstructors<typeof mapOfHybridsOrConstructors>;
 
   /* Factories */


### PR DESCRIPTION
Allows generation of the Hybrid constructor without definition custom element.

```javascript
const MyElement = {};
const Constructor = define(null, MyElement);

customElements.define("my-custom-name", Constructor);
```