### PR TITLE
docs: fix import statement in definition.md

### DIFF
--- a/docs/basics/definition.md
+++ b/docs/basics/definition.md
@@ -39,7 +39,7 @@ const MyElement = { ... };
 export default define(null, MyElement);
 
 // customer
-import { MyElement } from "components-library";
+import MyElement from "components-library";
 customElements.define("my-super-element", MyElement);
 ```
 


### PR DESCRIPTION
Since the "package" exports result of `define` call as a default the "customer" can't use named import