### PR TITLE
fix(types): uses 'export = not' and cannot be used with 'export *' Error

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,8 +1,4 @@
-// tslint:disable-next-line:export-just-namespace
-export = hybrids;
-export as namespace hybrids;
-
-declare namespace hybrids {
+declare module 'hybrids' {
   interface InvalidateOptions {
     force?: boolean;
   }


### PR DESCRIPTION
use module instead of namespace