### PR TITLE
feat(define): replace call for a map of components with tagged components

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,22 +31,21 @@
 
 ```html
 <script type="module">
-  import { html, define } from 'https://unpkg.com/hybrids@^5';
+  import { html, define } from 'https://unpkg.com/hybrids@^6';
   
   function increaseCount(host) {
     host.count += 1;
   }
 
-  const SimpleCounter = {
+  define({
+    tag: "simple-counter",
     count: 0,
     render: ({ count }) => html`
       <button onclick="${increaseCount}">
         Count: ${count}
       </button>
     `,
-  };
-
-  define('simple-counter', SimpleCounter);
+  });
 </script>
 
 <simple-counter count="10"></simple-counter>

--- a/docs/README.md
+++ b/docs/README.md
@@ -31,22 +31,21 @@
 
 ```html
 <script type="module">
-  import { html, define } from 'https://unpkg.com/hybrids@^5';
+  import { html, define } from 'https://unpkg.com/hybrids@^6';
   
   function increaseCount(host) {
     host.count += 1;
   }
 
-  const SimpleCounter = {
+  define({
+    tag: "simple-counter",
     count: 0,
     render: ({ count }) => html`
       <button onclick="${increaseCount}">
         Count: ${count}
       </button>
     `,
-  };
-
-  define('simple-counter', SimpleCounter);
+  });
 </script>
 
 <simple-counter count="10"></simple-counter>

--- a/docs/basics/definition.md
+++ b/docs/basics/definition.md
@@ -1,12 +1,84 @@
 # Definition
 
 ```javascript
-import { define } from 'hybrids';
+import { define } from "hybrids";
 ```
 
-To define web components from a map of descriptors use custom `define()` function.
+To define custom elements with hybrids, use custom `define()` function from the library.
 
-## Single Element
+## Tagged Definition
+
+```typescript
+define(descriptors: Object & { tag: string }): descriptors;
+```
+
+* **arguments**:
+  * `descriptors` - a map of hybrid property descriptors with string `tag` property in pascal case or camel case
+* **returns**:
+  * `descriptors` - passed argument to `define()` function
+
+The preferred way to structure and define web components with hybrids is to use a tagged definition and `define()` function within the same ES module.
+
+> The `tag` property only describes a custom element tag name, and it is not added to the constructor prototype. However, the `HTMLElement` prototype provides `tagName` computed property, which returns a uppercase version of the tag name.
+
+The function returns the passed definition object, so the following slick structure of the file can be used:
+
+```javascript
+import { define } from "hybrids";
+
+// Define single element with tag name included as a property,
+// returns the passed object
+export default define({
+  tag: "my-element",
+  ...
+});
+```
+
+The above structure allows very short syntax, and still ability to import the definition in another module, for example for unit testing. If you need access to the custom element constructor, you can use built-in method from the Custom Elements API:
+
+```javascript
+// defines a custom element with tag name included as a property
+import "./my-element.js";
+
+const MyElement = customElements.get("my-element");
+const el = new MyElement();
+```
+
+### Multiple Tagged Definitions
+
+```typescript
+define(...descriptors: Object[]): typeof descriptors;
+```
+
+* **arguments**:
+  * `descriptors` - a number of arguments of descriptors with string `tag` property in pascal case or camel case
+* **returns**:
+  * an array of `descriptors` objects
+
+An another approach for structuring files is to create a single index file, import all of the required definitions, and use the `define()` function once with all of the components:
+
+```javascript
+import { define } from "hybrids";
+
+import MyElement from "./my-element.js";
+import MyOtherElement from "./my-other-element.js";
+
+define(MyElement, MyOtherElement);
+```
+
+## Explicit Definition
+
+```typescript
+define(tagName: string | null, descriptors: Object): Wrapper
+```
+
+* **arguments**:
+  * `tagName` - a custom element tag name or `null`,
+  * `descriptors` - an object with a map of hybrid property descriptors
+* **returns**:
+  * `Wrapper` - custom element constructor (extends `HTMLElement`)
+
+The library still supports `define()` function with explicit tag name, but it is not preferred way and should be avoided. (It is considered to be deprecated in the future versions of the library).
 
 ```javascript
 import { define } from 'hybrids';
@@ -19,19 +91,9 @@ const MyElement = {
 define('my-element', MyElement);
 ```
 
-```typescript
-define(tagName: string | null, descriptors: Object): Wrapper
-```
-
-* **arguments**:
-  * `tagName` - a custom element tag name or `null`,
-  * `descriptors` - an object with a map of hybrid property descriptors
-* **returns**:
-  * `Wrapper` - custom element constructor (extends `HTMLElement`)
-
 ### Class Constructor
 
-If the `tagName` is set to `null`, the `define` function only generates class constructor without registering it in the global custom elements registry. This mode might be helpful for creating a custom element for external usage without depending on tag name, and where the `hybrids` library is not used directly.
+If the `tagName` is set to `null`, the explicit call to `define` function only generates class constructor without registering it in the global custom elements registry. This mode might be helpful for creating a custom element for external usage without depending on tag name, and where the `hybrids` library is not used directly.
 
 ```javascript
 // package
@@ -42,23 +104,3 @@ export default define(null, MyElement);
 import MyElement from "components-library";
 customElements.define("my-super-element", MyElement);
 ```
-
-## Multiple Elements
-
-```javascript
-import { define } from 'hybrids';
-import { MyElement, OtherElement } from 'some-elements';
-
-// Define one or more elements
-define({ MyElement, OtherElement, ... });
-```
-
-```typescript
-define({ tagName: descriptors, ... }): { tagName: Wrapper, ... }
-```
-
-* **arguments**:
-  * `tagName` - a custom element tag name in pascal case or camel case,
-  * `descriptors` - an object with a map of hybrid property descriptors
-* **returns**:
-  * `{ tagName: Wrapper, ...}` - a map of custom element constructors (extends `HTMLElement`)

--- a/docs/basics/descriptor.md
+++ b/docs/basics/descriptor.md
@@ -78,13 +78,14 @@ Cache mechanism uses equality check to compare values (`nextValue !== lastValue`
 In the following example, the `get` method of the `name` property is called again only if `firstName` or `lastName` has changed:
 
 ```javascript
-const MyElement = {
+define({
+  tag: "my-element",
   firstName: "John",
   lastName: "Smith",
   name: {
     get: ({ firstName, lastName }) => `${firstName} ${lastName}`,
   },
-};
+});
 
 console.log(myElement.name); // calls 'get' and returns 'John Smith'
 console.log(myElement.name); // Cache returns 'John Smith'
@@ -114,11 +115,12 @@ Every assertion of the property calls `set` method (like `myElement.property = '
 The following example shows the `power` property, which uses the default `get`, defines the `set` method, and calculates the power of the number passed to the property:
 
 ```javascript
-const MyElement = {
+define({
+  tag: "my-element",
   power: {
     set: (host, value) => value ** value,
   },
-};
+});
 
 myElement.power = 10; // calls 'set' method and set cache to 100
 console.log(myElement.power); // Cache returns 100
@@ -158,12 +160,13 @@ If the third party code is responsible for the property value, you can use `inva
 ```javascript
 import reduxStore from "./store";
 
-const MyElement = {
+define({
+  tag: "my-element",
   name: {
     get: () => reduxStore.getState().name,
     connect: (host, key, invalidate) => reduxStore.subscribe(invalidate),
   },
-};
+});
 ```
 
 `invalidate` can take an options object argument.

--- a/docs/core-features/events.md
+++ b/docs/core-features/events.md
@@ -36,12 +36,13 @@ function increaseCount(host) {
   dispatch(host, 'custom-change', { detail: host.value });
 }
 
-const MyElement = {
+define({
+  tag: "my-element",
   value: 0,
   render: ({ value }) => html`
     <button onclick="${increaseCount}">You clicked me ${value} times!</button>
   `,
-};
+});
 ```
 
 When using `<my-element>` elsewhere you can listen to `custom-change` event:
@@ -52,11 +53,12 @@ function notify(host, event) {
   console.log(event.detail);
 }
 
-const OtherElement = {
+define({
+  tag: "ohter-element",
   render: () =>  html`
     <my-element oncustom-change="${notify}"></my-element>
   `,
-};
+});
 ```
 
 Also, you can use `addEventListener` API just like for built-in elements:

--- a/docs/core-features/parent-children.md
+++ b/docs/core-features/parent-children.md
@@ -30,14 +30,16 @@ In the following example, `label` uses a `count` property of the `AppStore`. The
 ```javascript
 import { parent } from 'hybrids';
 
-const AppStore = {
+const AppStore = define({
+  tag: "app-store",
   count: 0,
-};
+});
 
-const MyElement = {
+define({
+  tag: "my-element",
   store: parent(AppStore),
   label: ({ store }) => `store count: ${store.count}`,
-}
+});
 ```
 
 ```html
@@ -70,17 +72,19 @@ deeper children. `nested` option allows adding nested children of that element i
 ```javascript
 import { children } from 'hybrids';
 
-const TabItem = {
+const TabItem = define({
+  tag: "tab-item",
   name: '',
   active: false,
   ...
-};
+});
 
-const TabGroup = {
+define({
+  tag: "tab-group",
   tabs: children(TabItem),
   active: ({ tabs }) => tabs.find((tab) => tab.active),
   ...
-};
+});
 ```
 
 ```html
@@ -97,13 +101,14 @@ const TabGroup = {
 ## Complex Conditions
 
 ```javascript
-const MyElement = {
+const MyElement = define({
+  tag: "my-element"
   // reference self - useful for tree-like structures
   parent: parent(hybrids => hybrids === MyElement),
   
   // any children, that has `value` property
   items: children(hybrids => hybrids.hasOwnProperty("value")),
-};
+});
 ```
 
 Use a `function` as an argument for complex conditions. For example, you can check if a part of the component definition contains specific property, or you can use it for self-reference.

--- a/docs/core-features/property.md
+++ b/docs/core-features/property.md
@@ -22,9 +22,10 @@ property(defaultValue: any, connect: Function, observe: Function): Object
 ```javascript
 import { property } from 'hybrids';
 
-const MyElement = {
+define({
+  tag: "my-element",
   value: property('text'),
-};
+});
 ```
 
 ### Translation
@@ -32,7 +33,7 @@ const MyElement = {
 You can omit explicit usage of the property factory by one of the [translation](../getting-started/concepts.md#translation) rules. If the property definition is a primitive or an array instance, the property factory will be used implicitly:
 
 ```javascript
-const MyElement = {
+{
   noTransform: undefined,
   object: null,
   number: 0,
@@ -69,12 +70,13 @@ The below example uses `moment` library as a function for `defaultValue` to tran
 import { property, html } from 'hybrids';
 import moment from 'moment';
 
-const MyElement = {
+define({
+  tag: "my-element",
   date: property(moment),
   render: ({ date }) => html`
     <p>${date.format("ddd, hA")}</p>
   `,
-};
+});
 ```
 
 ```html
@@ -88,14 +90,15 @@ The property factory for all types except `object` and `undefined` creates fallb
 Still, if you want to update property value you must assert new value to the property:
 
 ```javascript
-const MyElement = {
+define({
+  tag: "my-element",
   someValue: 0,
   render: () => html`
     <slot></slot>
   `.css`
     :host([some-value="100"]) { color: red }
   `,
-};
+});
 ```
 
 Attributes should be used only for setting static values in HTML templates:

--- a/docs/core-features/render.md
+++ b/docs/core-features/render.md
@@ -24,13 +24,14 @@ render(fn: Function, options: Object = { shadowRoot: true }): Object
 ```javascript
 import { render } from 'hybrids';
 
-export const MyElement = {
+define({
+  tag: "my-element",
   someProp: render((host) => {
     return (host, target) => {
       // update DOM here
     }
   }, { shadowRoot: ... })
-};
+});
 ```
 
 > Click and play with render factory example using [React](http://reactjs.org/) library:
@@ -52,13 +53,14 @@ The factory by default uses [Shadow DOM](https://developer.mozilla.org/docs/Web/
 ```javascript
 import { html, render } from 'hybrids';
 
-const MyElement = {
+define({
+  tag: "my-element",
   value: 1,
   render: render(
     ({ value }) => html`<div>${value}</div>`,
     { shadowRoot: false },
   ),
-};
+});
 ```
 
 ### Translation
@@ -70,11 +72,12 @@ You can omit explicit usage of the render factory by two of the [translation](..
     ```javascript
     import { html } from 'hybrids';
 
-    const MyElement = {
+    define({
+      tag: "my-element",
       value: 1,
       // Equals to render: render(({ value }) => html...
       render: ({ value }) => html`<div>${value}</div>`,
-    };
+    });
     ```
 
 2. If the `content` property definition is a function, the render factory renders to the host element content
@@ -82,11 +85,12 @@ You can omit explicit usage of the render factory by two of the [translation](..
     ```javascript
     import { html } from 'hybrids';
 
-    const MyElement = {
+    define({
+      tag: "my-element",
       value: 1,
       // Equals to content: render(({ value }) => ..., { shadowRoot: false }),
       content: ({ value }) => html`<div>${value}</div>`,
-    };
+    });
     ```
 
 ### Multiple Usage
@@ -100,7 +104,8 @@ const Data = {
   value: "My data",
 };
 
-const MyElement = {
+define({
+  tag: "my-element",
   data: store(Data),
   title: "",
   render: ({ title }) => html`
@@ -110,7 +115,7 @@ const MyElement = {
   content: ({ data }) => html`
     ${store.ready(data) && html`<p>${data.value}</p>`}
   `,
-}
+});
 ```
 
 In the result, in the Light DOM instance of the above element will look like this:
@@ -123,16 +128,17 @@ In the result, in the Light DOM instance of the above element will look like thi
 
 Notice that the `<p>` element will be putted inside of the `<div>` element of the host `shadowRoot`.
 
-If the layout structure repeats often, you define it outside of the component definition:
+If the layout structure repeats often, you define it outside of the component definition, as a factory resolving to the value accepted by the `render` property:
 
 ```javascript
-import ColumnLayout from "./layouts/column.js";
+import columnLayout from "./factories/layout.js";
 
-const MyElement = {
-  ...ColumnLayout,
+define({
+  tag: "my-element",
   data: store(Data),
+  render: layout("column"),
   content: ({ data }) => ...,
-};
+});
 ```
 
 ### Manual Update
@@ -154,7 +160,8 @@ console.log(target);
 If your element should expose internal parts of the content as a public API, you can use `render` property to define an internal DOM element from the rendered content as another property. Using `render` in the getter of the defined property ensures that render process is called and it adds it to the dependencies of the property. The result of the call gives us a `target` element, so you don't have to relay on the render configuration (it might be the `shadowRoot` as well as the `host` element - but both has `querySelector` API):
 
 ```javascript
-const MyCanvasElement = {
+define({
+  tag: "my-canvas-element",
   canvas: ({ render }) => {
     const target = render();
     return target.querySelector('canvas');
@@ -167,7 +174,7 @@ const MyCanvasElement = {
     </style>
     <canvas style="${{ width, height }}"></canvas>
   `,
-}
+});
 ```
 
 The `canvas` property from the above example will always reference the proper element from the shadowRoot. Even though the render process is asynchronous, if the user gets `canvas` before the first scheduled render, it will return the element interface because of calling `render()` manually. Moreover, the cache mechanism ensures that the `canvas` property result is cached. It is recalculated only when dependencies of the render property change. This allows creating dynamic selectors, which returns different results depends on the render dependencies.
@@ -186,7 +193,8 @@ function ref(query) {
   };
 }
 
-const MyElement = {
+define({
+  tag: "my-element",
   canvas: ref('canvas'),
   wrapper: ref('div#wrapper'),
   render: ({ ... }) => html`
@@ -195,7 +203,7 @@ const MyElement = {
       ...
     </div>
   `,
-}
+});
 ```
 
 ## Unit Testing
@@ -207,12 +215,13 @@ The render key is usually a function, which returns the update function. It can 
 ```javascript
 import { html } from 'hybrids';
 
-const MyElement = {
+const MyElement = define({
+  tag: "my-element",
   value: 1,
   render: ({ value }) => html`
     <div>${value}</div>
   `,
-};
+});
 
 it('should render value "1"', () => {
   const div = document.createElement('div');
@@ -237,10 +246,11 @@ import { html, render } from 'hybrids';
 // Take out template definition
 const renderTemplate = ({ value }) => html`<div>${value}</div>`;
 
-const MyElement = {
+const MyElement = define({
+  tag: "my-element",
   value: 1,
   render: render(renderTemplate, { shadowRoot: false }),
-};
+});
 
 it('should render value "1"', () => {
   const div = document.createElement('div');

--- a/docs/getting-started/concepts.md
+++ b/docs/getting-started/concepts.md
@@ -11,16 +11,15 @@ function increaseCount(host) {
   host.count += 1;
 }
 
-const SimpleCounter = {
+define({
+  tag: "simple-counter",
   count: 0,
   render: ({ count }) => html`
     <button onclick="${increaseCount}">
       Count: ${count}
     </button>
   `,
-};
-
-define('simple-counter', SimpleCounter);
+});
 ```
 
 > Click and play with `<simple-counter>` example:
@@ -44,9 +43,12 @@ customElements.define('my-element', MyElement);
 However, the class syntax is only a sugar on top of the constructors and prototypes. Because of that, it is possible to switch from class syntax to plain object with map of properties applied to the prototype of the custom element constructor.
 
 ```javascript
-const MyElement = {
+{
   property: {
-    get: ..., set: ..., connect: ..., observe: ...,
+    get() {...},
+    set() {...},
+    connect() {...},
+    observe() {...},
   },
   ...
 };
@@ -81,16 +83,18 @@ function connect(store, mapState) {
 
 ```javascript
 // Each instance is connected to `state.count` value
-const MyCountElement = {
+define({
+  tag: "my-count-element",
   count: connect(myReduxStore, (state) => state.count),
   render: ({ count }) => html`...`,
-};
+});
 
 // Each instance is connected to `state.other` value
-const MyOtherStateElement = {
+define({
+  tag: "my-other-state-element",
   other: connect(myReduxStore, (state) => state.other),
   render: ({ other }) => html`...`,
-}
+})
 ```
 
 > Click and play with [redux](redux.js.org) library integration example:
@@ -112,9 +116,10 @@ The translation feature uses set of rules for property definitions, which does n
 Instead of explicit usage of the `property` and `render` factories like this:
 
 ```javascript
-import { property, render, html } from 'hybrids';
+import { define, property, render, html } from 'hybrids';
 
-export const MyElement = {
+export default define({
+  tag: "my-element",
   count: property(0),
   render: render(({ count }) => html`
     <button>${count}</button>
@@ -125,9 +130,10 @@ export const MyElement = {
 You can write component definition using translation rules:
 
 ```javascript
-import { html } from 'hybrids';
+import { define, html } from 'hybrids';
 
-export const MyElement = {
+export default define({
+  tag: "my-element",
   count: 0,
   render: ({ count }) => html`
     <button>${count}</button>
@@ -135,7 +141,7 @@ export const MyElement = {
 }
 ```
 
-The process is done in the following order:
+The translation process is done in the following order:
 
 1. **`render` key descriptor with value as a function** translates to [`render`](../core-features/render.md) factory:
 

--- a/docs/misc/api-reference.md
+++ b/docs/misc/api-reference.md
@@ -5,24 +5,32 @@ The following functions are a public API of the hybrids library available as nam
 ## define
 
 ```typescript
+define(descriptors: Object & { tag: string }): descriptors;
+```
+
+* **arguments**:
+  * `descriptors` - a map of hybrid property descriptors with string `tag` property in pascal case or camel case
+* **returns**:
+  * `descriptors` - passed argument to `define()` function
+
+```typescript
+define(...descriptors: Object[]): typeof descriptors;
+```
+
+* **arguments**:
+  * `descriptors` - a number of arguments of descriptors with string `tag` property in pascal case or camel case
+* **returns**:
+  * an array of `descriptors` objects
+
+```typescript
 define(tagName: string, descriptors: Object): Wrapper
 ```
 
 * **arguments**:
-  * `tagName` - a custom element tag name,
+  * `tagName` - a custom element tag name or `null`,
   * `descriptors` - an object with a map of hybrid property descriptors
 * **returns**:
   * `Wrapper` - custom element constructor (extends `HTMLElement`)
-
-```typescript
-define({ tagName: descriptors, ... }): { tagName: Wrapper, ... }
-```
-
-* **arguments**:
-  * `tagName` - a custom element tag name in pascal case or camel case,
-  * `descriptors` - an object with a map of hybrid property descriptors
-* **returns**:
-  * `{ tagName: Wrapper, ...}` - a map of custom element constructors (extends `HTMLElement`)
 
 ## property
 

--- a/docs/misc/typescript.md
+++ b/docs/misc/typescript.md
@@ -12,7 +12,7 @@ A counter component example can be written in TS with the following code:
 ```typescript
 // simple-counter.ts
 
-import { define, html, Hybrids } from 'hybrids';
+import { define, html } from 'hybrids';
 
 interface SimpleCounter {
   count: number;
@@ -22,7 +22,7 @@ export function increaseCount(host: SimpleCounter) {
   host.count += 1;
 }
 
-export const SimpleCounter: Hybrids<SimpleCounter> = {
+export default define<SimpleCounter>({
   count: 0,
   render: ({ count }) => html`
     <button onclick="${increaseCount}">
@@ -30,8 +30,6 @@ export const SimpleCounter: Hybrids<SimpleCounter> = {
     </button>
   `,
 };
-
-define('simple-counter', SimpleCounter);
 ```
 
 The `Hybrids<E>` type has built-in support for the [descriptors structure](../core-concepts/descriptors.md) and all of the [translation](../core-concepts/translation.md) rules. It also prevents defining properties not declared in the interface. All hybrids public APIs support generic type `<E>` for providing the additional information from the defined interface, for example, `html<E>` or `define<E>(...)`. However, in most of the cases, it is not necessary to pass the generic type explicitly - TS calculates it from the `Hybrids<E>` main type.

--- a/docs/store/model.md
+++ b/docs/store/model.md
@@ -74,7 +74,7 @@ store.get([Model]) === store.get([Model])
 The listing type fits best for the models, which can be represented as an array (like memory-based models):
 
 ```javascript
-import { store, html } from 'hybrids';
+import { define, store, html } from 'hybrids';
 
 const Todo = {
   id: true,
@@ -82,7 +82,8 @@ const Todo = {
   checked: false,
 };
 
-const MyElement = {
+define({
+  tag: "my-element",
   todoList: store([Todo]),
   render: ({ todoList }) => html`
     <ul>
@@ -94,7 +95,7 @@ const MyElement = {
       `)}
     </ul>
   `,
-};
+});
 ```
 
 The listing type respects `cache` and `loose` options of the storage. By default the `loose` option is turn on, which means that the user's change to the model instance will invalidate the cache, and the next call for the list will fetch data again (read more in [Storage](./storage.md) section).

--- a/docs/store/overview.md
+++ b/docs/store/overview.md
@@ -28,10 +28,11 @@ export default Settings;
 Then, in the component definition use `store` factory to access values by the model definition:
 
 ```javascript
-import { store } from "hybrids";
+import { define, store } from "hybrids";
 import Settings, { setDarkTheme } from "./settings.js";
 
-const MyButton = {
+define({
+  tag: "my-button",
   settings: store(Settings),
   render: ({ settings }) => html`
     <style>
@@ -42,7 +43,7 @@ const MyButton = {
 
     <button onclick=${setDarkTheme}>Set dark theme</button>
   `,
-};
+});
 ```
 
 In the above example, the `setDarkTheme` function can be run outside of the component as well. It does not depend on the `host` element. Nevertheless, the component will re-render when `Settings` model instance changes.
@@ -68,10 +69,11 @@ The above `User` model definition creates a structure for each user instance wit
 Even though the source is external, interaction with the model is the same as with models from memory - there is no explicit call to the async storage:
 
 ```javascript
-import { store, html } from 'hybrids';
+import { define, store, html } from 'hybrids';
 import { User } from './models.js';
 
-const UserDetails = {
+define({
+  tag: "user-details",
   userId: '1',
   user: store(User, 'userId'),
   render: ({ user }) => html`
@@ -84,7 +86,7 @@ const UserDetails = {
       `}
     </div>
   `,
-}
+});
 ```
 
 > Click and play with `<store-user>` example:

--- a/docs/store/storage.md
+++ b/docs/store/storage.md
@@ -139,7 +139,8 @@ const Movie = {
   },
 };
 
-const MovieList = {
+define({
+  tag: "movie-list",
   query: '',
   year: 2020,
   movies: store([Movie], (host) => ({ query: host.query, year: host.year })),
@@ -150,7 +151,7 @@ const MovieList = {
       ${store.ready(movies) && movies.map(movie => html`<li>...</li>`)}
     </ul>
   `,
-}
+});
 ```
 
 In the above example, the `list` method uses the search feature of the API. Using the listing type, we can display a result page with movies filtered by query and year. However, the result of the listing mode cannot contain additional metadata. For such a case, create a separate definition with a nested array of models.
@@ -201,14 +202,15 @@ function refresh(host) {
   store.clear(host.emails, false);
 }
 
-const MyElement = {
+define({
+  tag: "my-element",
   emails: store([Email]),
   render: ({ emails }) => html`
     <button onclick="${refresh}">Refresh</button>
 
     ${store.ready(emails) && ...}
   `,
-}
+});
 ```
 
 #### Garbage Collector
@@ -270,7 +272,8 @@ const Model = {
   },
 };
 
-const MyElement = {
+define({
+  tag: "my-element",
   model: store(Model),
   socket: (host) => {
     const socket = io();
@@ -279,7 +282,7 @@ const MyElement = {
       store.sync(host.model, values);
     });
   },
-};
+});
 ```
 
 In the above example, even though the `Model` is connected to the external storage, when websocket emits an event, the values of the model updates without calling `[store.connect].set()`, as we expect. It is an update triggered by the server, so we don't want to send new values to the server again.

--- a/docs/store/usage.md
+++ b/docs/store/usage.md
@@ -43,12 +43,13 @@ function incCount(host) {
   store.set(GlobalState, { count: host.count + 1 });
 }
 
-const MyElement = {
+define({
+  tag: "my-element",
   count: () => store.get(GlobalState).count,
   render: ({ count }) => html`
     <button onclick=${incCount}>${count}</button>
   `,
-}
+});
 ```
 
 The above example uses a singleton memory-based model, so the data is available instantly. The `count` property can be returned directly inside of the host property definition. Even the `count` property of the host does not rely on other properties, the `render` property will be notified when the current value of the `GlobalState` changes (keep in mind that this approach creates a global state object, which is shared between all of the component instances).
@@ -145,14 +146,15 @@ function setDarkTheme(host, event) {
   store.set(host.user, { admin: true });
 }
 
-const MyElement = {
+define({
+  tag: "my-element",
   userId: "1",
   user: store(User, { id: "userId" }),
   render: ({ user }) => html`
     ...
     <button onclick="${setAdminRights}">Set admin rights</button>
   `,
-};
+});
 ```
 
 ### Singleton
@@ -162,11 +164,12 @@ If the model definition is a singleton, you can setup the property just with the
 ```javascript
 import { Settings } from "./models.js";
 
-const MyElement = {
+define({
+  tag: "my-element",
   settings: store(Settings),
   color: ({ settings }) => settings.darkTheme ? "white" : "black",
   ...
-};
+});
 ```
 
 ### Enumerable
@@ -176,7 +179,8 @@ For the enumerable model definition, the `id` can be set to the property name or
 ```javascript
 import { User, SearchResult }  from "./models.js";
 
-const MyElement = {
+define({
+  tag: "my-element",
   // Id from the host property (can be changed)
   userId: "1",
   user: store(User, "userId"), // using shorter syntax, equals to { id: "userId" }
@@ -191,7 +195,7 @@ const MyElement = {
   // Id not set - assertion to host.user sets the model instance
   // like: `el.user = "1"`, or `el.user = userModel`;
   user: store(User),
-};
+});
 ```
 
 #### Cache
@@ -205,7 +209,8 @@ function setNextPage(host) {
   host.page += 1;
 }
 
-const MyElement = {
+define({
+  tag: "my-element",
   page: 1,
   userList: store([User], "page"),
   render: ({ userList, page }) => html`
@@ -221,7 +226,7 @@ const MyElement = {
 
     <button onclick=${setNextPage}>Go to: ${page + 1}</button>
   `,
-};
+});
 ```
 
 In above example when the `page` changes, the `userList` property still returns the last page with the pending state from the next instance. Because of that, you can avoid a situation when the user sees an empty screen with loading indicator - the old data are displayed until the new one is ready to be displayed. However, you have an option to hide data immediately - use the `store.pending()` guard.
@@ -275,7 +280,8 @@ const CreateUserForm = {
 Combine `store.value()` in the definition for validation, and the `html.set(model, propertyPath)` helper from the template engine to update values without custom side effects (read more about the `html.set` for the store in the [`Event Listeners`](../template-engine/event-listeners.md#form-elements) section of the template engine documentation).
 
 ```javascript
-const MyInput = {
+define({
+  tag: "my-input",
   model: null,
   name: "",
   error: ({ model }) => store.error(model, name),
@@ -285,9 +291,10 @@ const MyInput = {
       ${error && html`<p class="error-message">${error}</p>`}
     </div>
   `,
-}
+});
 
-const MyUserForm = {
+define({
+  tag: "my-user-form",
   userId: "",
   user: store(User, { id: "userId", draft: true }),
   render: ({ user }) => html`
@@ -296,7 +303,7 @@ const MyUserForm = {
 
     <button onclick="${submit}>Save changes</button>
   `.define({ MyInput }),
-}
+});
 ```
 
 ## Guards
@@ -323,7 +330,8 @@ When the model instance is going to be updated (by setting a new value, or by ca
 ```javascript
 import { User } from "./models.js";
 
-const MyElement = {
+define({
+  tag: "my-element",
   userId: "1",
   user: store(User),
   render: ({ user }) => html`
@@ -335,7 +343,7 @@ const MyElement = {
       <p>Hide this message when new user is fetched</p>
     `}
   `,
-}
+});
 ```
 
 ### Pending
@@ -379,13 +387,14 @@ async function sendValue(host) {
   // do something with response
 }
 
-const MyElement = {
+define({
+  tag: "my-element",
   state: store(State),
   render: ({ state }) => html`
     <my-async-data-source onupdate="${html.set(state, "value")}"></my-async-data-source>
     <button onclick="${sendValue}">Send</button>
   `,
-};
+});
 ```
 
 ### Error
@@ -412,7 +421,8 @@ const User = {
   name: store.value("", /^[a-z]+$/),
 };
 
-const MyElement = {
+define({
+  tag: "my-element",
   user: store(User, { draft: true }),
   render: ({ user }) => html`
     <input value="${user.name}" oninput="${html.set(user, "name")} />
@@ -420,5 +430,5 @@ const MyElement = {
       ${store.error(user, "name")}
     </div>
   `,
-};
+});
 ```

--- a/docs/template-engine/dependencies.md
+++ b/docs/template-engine/dependencies.md
@@ -1,33 +1,38 @@
 # Dependencies
 
-Update function provides a helper method for resolving dependencies dynamically in templates, which use other custom elements. It uses `define` function from the library, so its API is similar to described in the [Definition](../core-concepts/definition.md) section. However, to properly work with templates it returns template update function, rather than a constructor or a map of constructors.
+Update function provides a helper method for resolving dependencies dynamically in templates, which use other custom elements. It uses `define` function from the library, so its API is similar to described in the [Definition](../core-concepts/definition.md) section. However, to properly work with templates it returns template update function, rather than descriptor or a map of descriptors.
 
 Resolving dependencies avoids defining not required elements and allows creating a tree-like dependency structure. A complex structure may require only one explicit definition at the root level. As the library factories decouple tag name from the definition, elements can have custom names.
 
 ```typescript
-html`...`.define(map: Object): Function
+html`...`.define(...descriptors: Object[]): Function
 ```
 
 * **arguments**:
   * `map` - object with hybrids definitions or custom element's constructors
 * **returns**:
-  * update function compatible with content expression 
+  * update function compatible with content expression
 
 ```javascript
-import UiHeader from './UiHeader';
+// The tagged definition
+const UiHeader = {
+  tag: "ui-header",
+  render: () => ...,
+};
 
-const UiCard = {
+export default define({
+  tag: "ui-card",
   withHeader: false,
 
   render: ({ withHeader }) => html`
     <div>
       ${withHeader && html`
         <ui-header>...</ui-header>
-      `.define({ UiHeader })}
+      `.define(UiHeader)}
       ...
     </div>
   `,
-};
+});
 ```
 
 In the above example, the customer of the `UiCard` element does not have to define `UiHeader` explicitly. It is defined inside of the rendering process, and only if `withHeader` resolves to `true`.

--- a/docs/template-engine/event-listeners.md
+++ b/docs/template-engine/event-listeners.md
@@ -10,7 +10,8 @@ function send(host, event) {
   sendData('api.com/create', { value: host.value });
 }
 
-const MyElement = {
+define({
+  tag: "my-element",
   value: 42,
   render: () => html`
     <form onsubmit="${send}">
@@ -69,13 +70,14 @@ function updateName(host, event) {
   host.name = event.target.value;
 }
 
-const MyElement = {
+define({
+  tag: "my-element",
   name: '',
   render: ({ name }) => html`
     <input type="text" defaultValue="${name}" oninput="${updateName}" />
     ...
   `,
-};
+});
 ```
 
 Using the above pattern may become verbose if your template contains many values to bind. The engine provides `html.set()` helper method, which generates callback function for setting host property from value of the element, or set store model property value.
@@ -99,7 +101,8 @@ The `html.set()` supports generic elements and unique behavior of the form eleme
 * For the rest elements, it uses `event.detail.value` if defined, or eventually `target.value` as default
 
 ```javascript
-const MyElement = {
+define({
+  tag: "my-element",
   option: false,
   date: null,
   render: ({ option, date }) => html`
@@ -111,7 +114,7 @@ const MyElement = {
     <!-- updates "host.option" with "event.detail.value" from the element -->
     <paper-toggle-button onchecked-changed="${html.set("option")}"></paper-toggle-button>
   `,
-};
+});
 ```
 
 #### Custom Value
@@ -119,7 +122,8 @@ const MyElement = {
 You can overwrite the default behavior and pass a custom value as a second parameter (`event.target.value` is not used):
 
 ```javascript
-const MyElement = {
+define({
+  tag: "my-element",
   items: [{ value: 1 }, { value: 2}],
   selected: null,
   render: ({ items }) => html`
@@ -132,7 +136,7 @@ const MyElement = {
       `)}
     </ul>
   `,
-}
+});
 ```
 
 In the above example, when a user clicks on the item button, the `selected` property is set to `item` from the loop.
@@ -155,7 +159,8 @@ html.set(model: object, propertyPath: string | null): Function
 import { store } from "hybrids";
 import User from "./models.js";
 
-const MyElement = {
+define({
+  tag: "my-element",
   user: store(User, { id: "userId", draft: true }),
   render: ({ user }) => html`
     <input
@@ -171,5 +176,5 @@ const MyElement = {
 
     <button onclick="${html.set(user, null)}">Delete user</button>
   `,
-};
+});
 ```

--- a/docs/template-engine/styling.md
+++ b/docs/template-engine/styling.md
@@ -7,14 +7,15 @@ To style your custom element, you can create `<style>` elements directly in the 
 Create `<style>` element inside of the main template passed to `render` factory:
 
 ```javascript
-const MyElement = {
+define({
+  tag: "my-element",
   render: () => html`
     <div>...</div>
     <style>
       div { color: red }
     </style>
   `,
-};
+});
 ```
 
 Styles are scoped and apply only to the elements in the `shadowRoot` for default render property configuration.
@@ -60,7 +61,8 @@ const commonStyles = html`
   </style>
 `;
 
-const MyElement = {
+define({
+  tag: "my-element",
   render: () => html`
     <div>...</div>
     ${commonStyles}
@@ -68,7 +70,7 @@ const MyElement = {
       div { color: red }
     </style>
   `,
-};
+});
 ```
 
 ## CSS Stylesheet
@@ -106,20 +108,22 @@ const inlineStyles = `
   div { color: red }
 `;
 
-const MyElement = {
+define({
+  tag: "my-element",
   render: () => html`
     <div>...</div>
   `.style(globals, styles, inlineStyles),
-};
+});
 
 // using css helper
-const OtherElement = {
+define({
+  tag: "other-element",
   render: () => html`
     <div>...</div>
   `.css`
     div { color: red }
   `,
-};
+});
 ```
 
 The style helper supports passing `CSSStyleSheet` instance, but it will work only for the mode described below. Do not use it if you target multiple environments, where it might not be yet supported.

--- a/docs/template-engine/values.md
+++ b/docs/template-engine/values.md
@@ -20,7 +20,8 @@ An expression with a function resolves to [nested template](./nested-templates.m
 If the expression returns a Node instance, it is attached to the corresponding place in the DOM. It can be useful for web components, which requires a reference to inner DOM elements:
 
 ```javascript
-const MyElement = {
+define({
+  tag: "my-element",
   // it will be called only once, as it has no deps
   canvas: () => { 
     const el = document.createElement("canvas");
@@ -38,5 +39,5 @@ const MyElement = {
       ${canvas}
     </div>
   `,
-};
+});
 ```

--- a/src/template/index.js
+++ b/src/template/index.js
@@ -11,8 +11,8 @@ const templatesMap = new Map();
 const stylesMap = new WeakMap();
 
 const methods = {
-  define(elements) {
-    defineElements(elements);
+  define(...elements) {
+    defineElements(...elements);
     return this;
   },
   key(id) {

--- a/test/spec/children.js
+++ b/test/spec/children.js
@@ -225,10 +225,12 @@ describe("children:", () => {
 
   describe("dynamic children", () => {
     const TestDynamicChild = {
+      tag: "TestDynamicChild",
       name: "",
     };
 
     const TestDynamicParent = {
+      tag: "TestDynamicParent",
       items: children(TestDynamicChild),
       render: ({ items }) => html`
         <div>
@@ -254,7 +256,7 @@ describe("children:", () => {
               `.key(name),
             )}
           </test-dynamic-parent>
-        `.define({ TestDynamicParent, TestDynamicChild }),
+        `.define(TestDynamicParent, TestDynamicChild),
     });
 
     const tree = test(`

--- a/test/spec/define.js
+++ b/test/spec/define.js
@@ -31,12 +31,15 @@ describe("define:", () => {
     expect(el.value).toBe("test");
   });
 
-  describe("for map argument", () => {
-    it("defines hybrids", done => {
-      const testHtmlDefine = { value: "test" };
-      const TestPascal = { value: "value-test-pascal" };
-      const HTMLDefine = { value: "value-html-define" };
-      define({ testHtmlDefine, TestPascal, HTMLDefine });
+  describe("for objects", () => {
+    it("defines tagged components", done => {
+      const testHtmlDefine = { tag: "testHtmlDefine", value: "test" };
+      const TestPascal = { tag: "TestPascal", value: "value-test-pascal" };
+      const HTMLDefine = { tag: "HTMLDefine", value: "value-html-define" };
+      const result = define(testHtmlDefine, TestPascal, HTMLDefine);
+
+      expect(result).toEqual([testHtmlDefine, TestPascal, HTMLDefine]);
+      expect(define(HTMLDefine)).toBe(HTMLDefine);
 
       requestAnimationFrame(() => {
         const testHtmlDefineEl = document.createElement("test-html-define");
@@ -51,9 +54,12 @@ describe("define:", () => {
       });
     });
 
-    it("throws for invalid value", () => {
+    it("throws for element without 'tag' string property", () => {
       expect(() => {
-        define({ testHtmlDefineExternalD: "value" });
+        define({ value: "test" });
+      }).toThrow();
+      expect(() => {
+        define({ tag: 0, value: "test" });
       }).toThrow();
     });
   });

--- a/test/spec/html.js
+++ b/test/spec/html.js
@@ -1296,6 +1296,7 @@ describe("html:", () => {
 
   describe("ShadyCSS custom property scope", () => {
     const TestShadyChild = {
+      tag: "test-shady-child",
       value: 0,
       render: ({ value }) => html`
         <span>${value}</span>
@@ -1308,6 +1309,7 @@ describe("html:", () => {
     };
 
     const TestShadyParent = {
+      tag: "test-shady-parent",
       active: false,
       render: ({ active }) =>
         html`
@@ -1320,10 +1322,10 @@ describe("html:", () => {
               --custom-color: blue;
             }
           </style>
-        `.define({ TestShadyChild }),
+        `,
     };
 
-    define("test-shady-parent", TestShadyParent);
+    define(TestShadyParent, TestShadyChild);
 
     const shadyTree = test(`
       <test-shady-parent></test-shady-parent>

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -41,10 +41,11 @@ declare module "hybrids" {
         ? RenderFunction<E>
         : Property<E, E[property]>
       : Property<E, E[property]>;
-  } & {
-    render?: RenderFunction<E> | Descriptor<E, () => HTMLElement>;
-    content?: RenderFunction<E> | Descriptor<E, () => HTMLElement>;
-  };
+  } &
+    (E extends { tag: any } ? {} : { tag?: string }) & {
+      render?: RenderFunction<E> | Descriptor<E, () => HTMLElement>;
+      content?: RenderFunction<E> | Descriptor<E, () => HTMLElement>;
+    };
 
   interface MapOfHybrids {
     [tagName: string]: Hybrids<any>;
@@ -68,9 +69,8 @@ declare module "hybrids" {
     hybrids: Hybrids<E>,
   ): HybridElement<E>;
 
-  function define(
-    mapOfHybrids: MapOfHybrids,
-  ): MapOfConstructors<typeof mapOfHybrids>;
+  function define<E>(hybrids: Hybrids<E>): typeof hybrids;
+  function define(listOfHybrids: Hybrids<any>[]): typeof listOfHybrids;
 
   /* Factories */
 


### PR DESCRIPTION
BREAKING CHANGE: Passing a map of components to the `define()` function is no longer supported. Object argument will be interpreted as a tagged component definition. A preferred way to refactor old code is to extend the definition of the component with the `tag` property, and pass definitions to the `define()` function as a list of arguments. If your definition contains `tag` property with another purpose, you can still use the `define(tagName, descriptors)` version.

From:
```js
const MyElement = { ... };
const MyOtherElement = { ... };

define({ MyElement, MyOtherElement });
```
To:
```js
const MyElement = { tag: "my-element", .. };
const MyOtherElement = { tag: "my-other-element", ... };

define(MyElement, MyOtherElement);
```