### PR TITLE
fix(store): set the storage loose option default value to `false`

### DIFF
--- a/docs/store/model.md
+++ b/docs/store/model.md
@@ -23,7 +23,7 @@ const Model = {
 }
 ```
 
-The `id` property indicates if the model has multiple instances, or it is a singleton. The only valid value for the `id` field is `true`. Otherwise, it should not be defined at all. For example, you may need only one instance of the `Profile` model of the current logged in user, but it can reference an enumerable `User` model.
+The `id` property indicates if the model has multiple instances, or it is a singleton. The only valid value for the `id` field is `true`. Otherwise, it should not be defined. For example, you may need only one instance of the `Profile` model of the current logged in user, but it can reference an enumerable `User` model.
 
 ```javascript
 const User = {
@@ -97,7 +97,7 @@ const MyElement = {
 };
 ```
 
-The listing type respects `cache` and `loose` options of the storage. By default the `loose` option is turn on, which means that the user's change to the model instance will invalidate the cache, and the next call for the list will fetch data again (read more in [Storage](./storage.md) section).
+The listing type respects `cache` and `loose` options of the storage. By default the `loose` option is turn off for external storages (read more in [Storage](./storage.md) section).
 
 #### Metadata
 
@@ -242,11 +242,38 @@ If the first item of the array is a primitive or an internal object instance (ac
 import OtherModel from './otherModel.js';
 
 const Model = {
-  items: [OtherModel],
+  items: [OtherModel, { loose: false | true = false }],
 };
 ```
 
-If the first item of the array is an enumerable model definition, the property represents a list of external model instances mapped by their ids. The parent model's storage may provide a list of data for model instances or a list of identifiers. The update process and binding between models work the same as for a single external nested object.
+If the first item of the array is an enumerable model definition, the property represents a list of external model instances mapped by their ids. The second item is an optional options object with `loose` option.
+
+The parent model's storage may provide a list of data for model instances or a list of identifiers. The update process and binding between models work the same as for a single external nested object.
+
+### Cache Invalidation
+
+By default, the store does not invalidate the cached value of the model instance when nested in the array external model changes. Because of the nature of the binding between models, when the nested model updates its state, the change will be reflected without a need to update the parent model's state.
+
+However, the list value might be related to the current state of nested models. For example, the model definition representing a paginated structure ordered by name must update when one of the nested model changes. After the change, the result pages might have a different content. To support that case, you can pass a second object to the nested array definition with `loose` option:
+
+```javascript
+import { store } from 'hybrids';
+import User from './user.js';
+
+const UserList = {
+  id: true,
+  users: [User, { loose: true }],
+  ...,
+  [store.connect]: (params) => api.get('/users/search', params),
+};
+
+const pageOne = store.get(UserList, { page: 1, query: '' });
+
+// Updates some user and invalidates cached value of the `pageOne` model instance
+store.set(pageOne.users[0], { name: 'New name' });
+```
+
+To prevent an endless loop of fetching data, the cached value of the parent model instance only invalidates if the `store.set` method is used. Updating the state of the nested model definition by fetching new values with `store.get` action won't invalidate the parent model. Get action still respects the `cache` option of the parent storage. If you need a high rate of accuracy of the external data, you should set a very low value of the `cache` option in the storage, or even set it to `false`.
 
 ### Self Reference & Import Cycles
 
@@ -270,28 +297,3 @@ const Model = {
 ```
 
 In the above example, the `Model` defines a connected list structure, where each instance can reference to the same definition.
-
-### Cache Invalidation
-
-By default, the store does not invalidate the cached value of the parent model instance when nested external model changes. Because of the nature of the binding between models, when the nested model updates its state, the change will be reflected without a need to update the parent model's state.
-
-However, the list might be related to the current state of nested models. For example, the model definition representing a paginated structure ordered by name must update when one of the nested model changes. After the change, the result pages might have a different content. To support that case, you can pass a second object to the nested array definition with `loose` option:
-
-```javascript
-import { store } from 'hybrids';
-import User from './user.js';
-
-const UserList = {
-  id: true,
-  users: [User, { loose: true }],
-  ...,
-  [store.connect]: (params) => api.get('/users/search', params),
-};
-
-const pageOne = store.get(UserList, { page: 1, query: '' });
-
-// Updates some user and invalidates cached value of the `pageOne` model instance
-store.set(pageOne.users[0], { name: 'New name' });
-```
-
-To prevent an endless loop of fetching data, the cached value of the parent model instance only invalidates if the `store.set` method is used. Updating the state of the nested model definition by fetching new values with `store.get` action won't invalidate the parent model. Get action still respects the `cache` option of the parent storage. If you need a high rate of accuracy of the external data, you should set a very low value of the `cache` option in the storage, or even set it to `false`.

--- a/docs/store/storage.md
+++ b/docs/store/storage.md
@@ -33,7 +33,7 @@ store.set(Globals, null).then(() => {
 
 ### Enumerable
 
-For the enumerables, the memory storage returns models, which were created before. It also supports listing all models.
+For the enumerables, the memory storage returns models, which were created by the client. It supports the list action, which always returns all existing models. The storage `loose` option is turned on to invalidate the list state when one of the models updates.
 
 ```javascript
 const Todo = {
@@ -58,7 +58,7 @@ const Model = {
     set?: (id, values, keys) => {...},
     list?: (id) => {...},
     cache?: boolean | number [ms] = true,
-    loose?: boolean = true,
+    loose?: boolean = false,
   },
 };
 ```
@@ -218,30 +218,14 @@ The `store.clear()` method works as a garbage collector for unused model instanc
 ### loose
 
 ```typescript
-loose: boolean = true
+loose: boolean = false
 ```
 
-The `loose` option of the model only affects listing enumerable models cache invalidation (the `loose` option of the nested array is still respected). By default, it is set to `true`, which means, that any change to model instance invalidates result of list action. The typical use case for that value would be when you have paginated list, and updating or creating a model instance might affect order or content of the list.
+The `loose` option of the model only affects cache invalidation of the listing enumerable models (the `loose` option of the nested array in the model definition is still respected). 
 
-If the result of list action should not be invalidated when model instance changes, set this option to `false`. Using that value you can avoid unnecessary calls to external storage, when the list result does not depend on the model instance values.
+By default, it is set to `false`, so updating model instances will not change items order or placement in the array. The typical use case to turn it on is when you have a paginated list, and updating or creating a model instance might affect order or content of the list. 
 
-```javascript
-const Notification = {
-  id: true,
-  content: "",
-  read: "",
-  createdAt: "",
-  [store.connect]: {
-    set: (id, values) => api.put('/notifications', id, values),
-    list: ({ page }) => api.get('/notifications', { page }),
-    loose: false,
-  },
-};
-```
-
-In the above example, the list returns paginated notifications ordered by the creation time. When you want to set notification as read, you don't need to fetch list again, as the model instance updates itself and the list does not change.
-
-Keep in mind, that setting `loose` option to `false` blocks invalidation also when new model instances are created. This option should only be set to `false` for models not fully controlled by the user.
+If the user does not have control over the model, it is recommended to keep that option off. You can avoid unnecessary calls to external storage, when the list result does not depend on the model instance values.
 
 ## Observables
 

--- a/src/store.js
+++ b/src/store.js
@@ -81,7 +81,7 @@ function invalidateTimestamp(model) {
 function setupStorage(storage) {
   if (typeof storage === "function") storage = { get: storage };
 
-  const result = { cache: true, loose: true, ...storage };
+  const result = { cache: true, loose: false, ...storage };
 
   if (result.cache === false || result.cache === 0) {
     result.validate = cachedModel =>
@@ -120,6 +120,7 @@ function memoryStorage(config) {
           return acc;
         }, []);
       },
+    loose: true,
   };
 }
 

--- a/test/spec/store.js
+++ b/test/spec/store.js
@@ -1635,6 +1635,7 @@ describe("store:", () => {
             return null;
           },
           list: () => Object.keys(storage).map(key => storage[key]),
+          loose: true,
         },
       };
     });
@@ -1817,6 +1818,7 @@ describe("store:", () => {
             return storage[id];
           },
           list: () => Object.keys(storage).map(key => storage[key]),
+          loose: true,
         },
       };
 
@@ -2170,6 +2172,7 @@ describe("store:", () => {
             }),
           set: (id, values) => Promise.resolve(values),
           list: () => Promise.resolve(["1"]),
+          loose: true,
         },
       };
 
@@ -2195,6 +2198,7 @@ describe("store:", () => {
           cache: 1000 * 30,
           get: () => {},
           list: () => Promise.resolve([{ id: "1", value: "test" }]),
+          loose: true,
         },
       };
 


### PR DESCRIPTION
BREAKING CHANGE: From now, for external storage, the result of the list action will not invalidate when the model instance is changed. The items within the list are still updated, but deletion or creating a model instance won't update the list unless you set the storage `loose` option to `true`. However, the default value change only applies to listing enumerable models with external storage, which can be changed by the user. For most of the case, you should ok, without additional change in the code.