### PR TITLE
feat(html): Add support for Transition API and `use` helper method

### DIFF
--- a/docs/component-model/layout-engine.md
+++ b/docs/component-model/layout-engine.md
@@ -235,6 +235,12 @@ Use following examples as a reference:
 | left   | [value:dimension] | left:0   | `left: [value]`                  |
 | layer  | [index:value]     | layer:1  | `z-index: [index]`               |
 
+### Transition API
+
+| Rule | Arguments     | Defaults | Properties                     |
+|------|---------------|----------|--------------------------------|
+| view | [name:value]  | ---      | `view-transition-name: [name]` |
+
 ## Generic Values
 
 You can extend ruleset supported by the layout engine by using special empty rule `::`. It generates a CSS property with a value set to CSS variable based on its name. In another words, it allows to use predefined design tokens, which points any CSS properties.

--- a/docs/component-model/templates.md
+++ b/docs/component-model/templates.md
@@ -570,7 +570,7 @@ define({
 });
 ```
 
-Keep in mind, that the transition API will be trigger only when element, which uses `html.transition` updates. In the above example, it will be triggered only when `stack` property changes. Any change to internal elements of the `stack` will not trigger the transition.
+!> The transition API will be trigger only when element, which uses `html.transition` updates. In the above example, it will be triggered only when `stack` property changes. Any change to internal elements of the `stack` will not trigger the transition.
 
 The transition API can be customized by the CSS properties. The DOM elements might have custom view transition names. The [layout engine](./layout-engine.md) supports `view` rule, which sets it:
 

--- a/docs/misc/api-reference.md
+++ b/docs/misc/api-reference.md
@@ -101,6 +101,16 @@ html`...`.style(...styles: Array<string | CSSStyleSheet>): Function
 html`...`.css`div { color: red; padding-top: ${value}; }`: Function
 ```
 
+```typescript
+html`...`.use(plugin: (fn: ((host, target) => void) => (host, target) => void): Function
+```
+
+- **arguments**:
+  - `plugin` - a function, which takes the original update function and returns a new update function
+- **returns**:
+  - an update function compatible with content expression
+
+
 - **arguments**:
   - CSS content in tagged template literals
   - `value` - dynamic values concatenated with the template literal
@@ -122,11 +132,11 @@ html.resolve(promise: Promise, placeholder: Function, delay = 200): Function
 html.set(propertyName: string, value?: any): Function
 ```
 
-* **arguments**:
-  * `propertyName` - a target host property name
-  * `value` - a custom value, which will be set instead of `event.target.value`
-* **returns**:
-  * a callback function compatible with template engine event listener
+- **arguments**:
+  - `propertyName` - a target host property name
+  - `value` - a custom value, which will be set instead of `event.target.value`
+- **returns**:
+  - a callback function compatible with template engine event listener
 
 ```typescript
 svg`<circle property="${value}">${value}</circle>` : Function
@@ -154,6 +164,15 @@ svg`...`.css`path { color: ${value}; }`: Function
 - **arguments**:
   - CSS content in tagged template literals
   - `value` - dynamic values concatenated with the template literal
+- **returns**:
+  - an update function compatible with content expression
+
+```typescript
+svg`...`.use(plugin: (fn: ((host, target) => void) => (host, target) => void): Function
+```
+
+- **arguments**:
+  - `plugin` - a function, which takes the original update function and returns a new update function
 - **returns**:
   - an update function compatible with content expression
 

--- a/docs/router/usage.md
+++ b/docs/router/usage.md
@@ -35,16 +35,15 @@ router(views: component | component[] | () => ..., options?: object): object
   * `options` - an object with following options:
     * `url` - a string base URL used for views without own `url` option, defaults to current URL
     * `params` - an array of property names of the element, which are passed to every view as a parameter
+    * `transition` - a boolean flag to enable notifications about the transition type between views by setting `<html router-transition="">` element's attribute
 * **returns**:
   * a hybrid property descriptor, which resolves to an array of elements
 
-### Arguments
-
-#### `views`
+### `views`
 
 Views passed to the router factory create the roots of the view structures. Usually, there is only one root view, but you can pass a list of them (navigating between roots always replaces the whole stack). You can find a deeper explanation of the view concept in the [View](/router/view.md) section.
 
-#### `options.url`
+### `options.url`
 
 If your application uses a mixed approach - views with and without URLs, you should specify a base URL to avoid not deterministic behavior of the router for views without the URL. Otherwise, the router will use an entry point as a base URL (which can be different according to the use case).
 
@@ -56,7 +55,7 @@ define({
 })
 ```
 
-#### `options.params`
+### `options.params`
 
 Regardless of the explicit parameters when navigating to the view, you can specify an array of properties of the component, which are passed to every view as a parameter. They bypass the URL generation, so they are set by the reference, and they are not included in the URL.
 
@@ -79,6 +78,29 @@ define({
 
 ```html
 <my-app user="123"></my-app>
+```
+
+### `options.transition`
+
+The `transition` option enables notifications about the transition type between views set in `<html router-transition="">` element's attribute with the following values:
+
+* `""` - empty when the router displays view stack for the first time
+* `forward` - when the user navigates to nested view
+* `backward` - when the user navigates backward to parent view
+* `replace` - when the user replaces the current view
+
+The `transition` option is useful for animations, like using [Transition API](/component-model/templates.md#transition-api), which should be triggered only when the user navigates between views.
+
+```html
+<style>
+  [router-transition="backward"]::view-transition-old(root) {
+    animation-name: fade-out, slide-to-right;
+  }
+
+  [router-transition="backward"]::view-transition-new(root) {
+    animation-name: fade-in, slide-from-left;
+  }
+</style>
 ```
 
 ## Nested Routers

--- a/src/template/core.js
+++ b/src/template/core.js
@@ -446,7 +446,7 @@ export function compileTemplate(rawParts, isSVG, isMsg, useLayout) {
   }
 
   const partsKeys = Object.keys(parts);
-  return function updateTemplateInstance(host, target, args, styles) {
+  return function updateTemplateInstance(host, target, args, { styleSheets }) {
     let meta = getMeta(target);
 
     if (template !== meta.template) {
@@ -512,7 +512,7 @@ export function compileTemplate(rawParts, isSVG, isMsg, useLayout) {
       if (useLayout) layout.inject(target);
     }
 
-    updateStyles(target, styles);
+    updateStyles(target, styleSheets);
 
     for (const marker of meta.markers) {
       const value = args[marker.index];

--- a/src/template/helpers/index.js
+++ b/src/template/helpers/index.js
@@ -1,0 +1,3 @@
+export { default as resolve } from "./resolve.js";
+export { default as set } from "./set.js";
+export { default as transition } from "./transition.js";

--- a/src/template/helpers/resolve.js
+++ b/src/template/helpers/resolve.js
@@ -1,0 +1,33 @@
+import resolveTemplateValue from "../resolvers/value.js";
+
+const promiseMap = new WeakMap();
+export default function resolve(promise, placeholder, delay = 200) {
+  return function fn(host, target) {
+    const useLayout = fn.useLayout;
+    let timeout;
+
+    if (placeholder) {
+      timeout = setTimeout(() => {
+        timeout = undefined;
+        resolveTemplateValue(host, target, placeholder, undefined, useLayout);
+      }, delay);
+    }
+
+    promiseMap.set(target, promise);
+
+    promise.then((value) => {
+      if (timeout) clearTimeout(timeout);
+
+      if (promiseMap.get(target) === promise) {
+        resolveTemplateValue(
+          host,
+          target,
+          value,
+          placeholder && !timeout ? placeholder : undefined,
+          useLayout,
+        );
+        promiseMap.set(target, null);
+      }
+    });
+  };
+}

--- a/src/template/helpers/set.js
+++ b/src/template/helpers/set.js
@@ -1,5 +1,4 @@
-import { storePointer } from "../utils.js";
-import resolveTemplateValue from "./resolvers/value.js";
+import { storePointer } from "../../utils.js";
 
 function resolveValue({ target, detail }, setter) {
   let value;
@@ -34,7 +33,7 @@ function getPartialObject(name, value) {
 
 const stringCache = new Map();
 
-export function set(property, valueOrPath) {
+export default function set(property, valueOrPath) {
   if (!property) {
     throw Error(
       `The first argument must be a property name or an object instance: ${property}`,
@@ -86,36 +85,4 @@ export function set(property, valueOrPath) {
   }
 
   return fn;
-}
-
-const promiseMap = new WeakMap();
-export function resolve(promise, placeholder, delay = 200) {
-  return function fn(host, target) {
-    const useLayout = fn.useLayout;
-    let timeout;
-
-    if (placeholder) {
-      timeout = setTimeout(() => {
-        timeout = undefined;
-        resolveTemplateValue(host, target, placeholder, undefined, useLayout);
-      }, delay);
-    }
-
-    promiseMap.set(target, promise);
-
-    promise.then((value) => {
-      if (timeout) clearTimeout(timeout);
-
-      if (promiseMap.get(target) === promise) {
-        resolveTemplateValue(
-          host,
-          target,
-          value,
-          placeholder && !timeout ? placeholder : undefined,
-          useLayout,
-        );
-        promiseMap.set(target, null);
-      }
-    });
-  };
 }

--- a/src/template/helpers/transition.js
+++ b/src/template/helpers/transition.js
@@ -1,0 +1,32 @@
+import global from "../../global.js";
+import { deferred, stringifyElement } from "../../utils.js";
+
+let instance;
+export default (global.document &&
+  global.document.startViewTransition !== undefined &&
+  function transition(template) {
+    return function fn(host, target) {
+      if (instance) {
+        console.warn(
+          `${stringifyElement(
+            host,
+          )}: view transition already started in ${stringifyElement(instance)}`,
+        );
+        template(host, target);
+        return;
+      }
+
+      template.useLayout = fn.useLayout;
+      instance = host;
+
+      global.document.startViewTransition(() => {
+        template(host, target);
+
+        return deferred.then(() => {
+          instance = undefined;
+        });
+      });
+    };
+  }) ||
+  // istanbul ignore next
+  ((fn) => fn);

--- a/src/template/index.js
+++ b/src/template/index.js
@@ -1,37 +1,13 @@
 import { compileTemplate } from "./core.js";
 import { getPlaceholder } from "./utils.js";
-import * as helpers from "./helpers.js";
+
+import * as helpers from "./helpers/index.js";
+import * as methods from "./methods.js";
 
 const PLACEHOLDER = getPlaceholder();
 const PLACEHOLDER_SVG = getPlaceholder("svg");
 const PLACEHOLDER_MSG = getPlaceholder("msg");
 const PLACEHOLDER_LAYOUT = getPlaceholder("layout");
-
-const methods = {
-  key(id) {
-    this.id = id;
-    return this;
-  },
-  style(...styles) {
-    this.styleSheets = this.styleSheets || [];
-    this.styleSheets.push(...styles);
-
-    return this;
-  },
-  css(parts, ...args) {
-    this.styleSheets = this.styleSheets || [];
-
-    let result = parts[0];
-    for (let index = 1; index < parts.length; index++) {
-      result +=
-        (args[index - 1] !== undefined ? args[index - 1] : "") + parts[index];
-    }
-
-    this.styleSheets.push(result);
-
-    return this;
-  },
-};
 
 const templates = new Map();
 export function compile(parts, args, isSVG, isMsg) {
@@ -47,7 +23,14 @@ export function compile(parts, args, isSVG, isMsg) {
       templates.set(id, render);
     }
 
-    render(host, target, args, template.styleSheets);
+    if (template.plugins) {
+      template.plugins.reduce(
+        (acc, plugin) => plugin(acc),
+        () => render(host, target, args, template),
+      )(host, target);
+    } else {
+      render(host, target, args, template);
+    }
   }
 
   return Object.assign(template, methods);

--- a/src/template/layout.js
+++ b/src/template/layout.js
@@ -1,6 +1,8 @@
 import global from "../global.js";
 
-const hasAdoptedStylesheets = !!global.document.adoptedStyleSheets;
+const hasAdoptedStylesheets = !!(
+  global.document && global.document.adoptedStyleSheets
+);
 const NUMBER_REGEXP = /^\d+$/;
 const rules = {
   // base
@@ -159,6 +161,7 @@ const rules = {
       [args[args.length - 2]]: `var(--${args.join("-")})`,
     };
   },
+  view: (props, value) => ({ "view-transition-name": value }),
 };
 
 const dimensions = {

--- a/src/template/methods.js
+++ b/src/template/methods.js
@@ -1,0 +1,32 @@
+export function key(id) {
+  this.id = id;
+  return this;
+}
+
+export function style(...styles) {
+  this.styleSheets = this.styleSheets || [];
+  this.styleSheets.push(...styles);
+
+  return this;
+}
+
+export function css(parts, ...args) {
+  this.styleSheets = this.styleSheets || [];
+
+  let result = parts[0];
+  for (let index = 1; index < parts.length; index++) {
+    result +=
+      (args[index - 1] !== undefined ? args[index - 1] : "") + parts[index];
+  }
+
+  this.styleSheets.push(result);
+
+  return this;
+}
+
+export function use(plugin) {
+  this.plugins = this.plugins || [];
+  this.plugins.push(plugin);
+
+  return this;
+}

--- a/test/spec/layout.js
+++ b/test/spec/layout.js
@@ -568,4 +568,17 @@ describe("layout:", () => {
     const styles1 = window.getComputedStyle(host.children[1]);
     expect(styles1.font).toBe("24px sans-serif");
   });
+
+  if (document.startViewTransition) {
+    it("supports transition view name", () => {
+      html`
+        <template layout>
+          <div layout="view:test"></div>
+        </template>
+      `(host);
+
+      const styles0 = window.getComputedStyle(host.children[0]);
+      expect(styles0.viewTransitionName).toBe("test");
+    });
+  }
 });

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -318,6 +318,7 @@ declare module "hybrids" {
     key: (id: any) => this;
     style: (...styles: Array<string | CSSStyleSheet>) => this;
     css: (parts: TemplateStringsArray, ...args: unknown[]) => this;
+    use: (fn: (template: UpdateFunction<E>) => UpdateFunction<E>) => this;
   }
 
   interface EventHandler<E> {
@@ -341,6 +342,8 @@ declare module "hybrids" {
       placeholder?: UpdateFunction<E>,
       delay?: number,
     ): UpdateFunction<E>;
+
+    function transition<E>(template: UpdateFunction<E>): UpdateFunction<E>;
 
     function msg(parts: TemplateStringsArray, ...args: unknown[]): string;
   }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -225,6 +225,7 @@ declare module "hybrids" {
     options?: {
       url?: string;
       params?: Array<keyof E>;
+      transition?: boolean;
     },
   ): Descriptor<E, HTMLElement[]>;
 


### PR DESCRIPTION
Fixes #193.

The PR adds support for Transition API recently added to Chrome 111. It extends `html` helpers with `html.transition` method, which should wrap the top-most component from the tree structure, where an update of the content/render should trigger `startViewTransition` process.

It's the first iteration of the implementation, the API can be changed if you have a simpler/better idea. If other features of the Transition API might be required, the `html.transition(fn, options = { ... })` can be extended with some `options` object as a second argument (?).

Simple example:

```js
define({
  tag: "test-html-transition",
  content: ({ value }) =>
    html.transition(
      html`<div>${value}</div>`,
    ),
});
```

The layout engine was extended with `view` rule, which allows adding view transition name, like: 

```html
<div layout="view:header"></div>
```