### PR TITLE
Update package.json exports to include types

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,12 @@
   "version": "8.2.0",
   "description": "A JavaScript framework for creating fully-featured web applications, components libraries, and single web components with unique declarative and functional architecture",
   "type": "module",
-  "exports": "./src/index.js",
+  "exports": {
+   ".": {
+     "types": "./types/index.d.ts",
+     "default": "./src/index.js"
+   } 
+  },
   "types": "types/index.d.ts",
   "bin": "./cli/index.js",
   "sideEffects": false,


### PR DESCRIPTION
Needed for newer typescript with certain moduleResolution settings.

Found the explanation & solution here:
https://github.com/gxmari007/vite-plugin-eslint/pull/60

& the docs for the option here:
https://nodejs.org/api/packages.html#packages_exports (with `types` being defined here: https://nodejs.org/api/packages.html#conditional-exports)