### PR TITLE
fix(cache): Clear deps and context when get value from cache

### DIFF
--- a/src/cache.js
+++ b/src/cache.js
@@ -10,18 +10,10 @@ function dispatch(entry) {
   while (entry) {
     entry.resolved = false;
 
-    if (entry.deps) {
-      for (const depEntry of entry.deps) {
-        depEntry.contexts.delete(entry);
-      }
-      entry.deps.clear();
-    }
-
     if (entry.contexts) {
       for (const context of entry.contexts) {
-        if (!stack.has(context)) {
-          if (!contexts.includes(context)) contexts.push(context);
-          entry.contexts.delete(context);
+        if (!stack.has(context) && !contexts.includes(context)) {
+          contexts.push(context);
         }
       }
     }
@@ -78,6 +70,13 @@ export function get(target, key, getter) {
   }
 
   if (entry.resolved) return entry.value;
+
+  if (entry.deps) {
+    for (const depEntry of entry.deps) {
+      depEntry.contexts.delete(entry);
+    }
+    entry.deps.clear();
+  }
 
   const lastContext = context;
 
@@ -173,6 +172,20 @@ function invalidateEntry(entry, options) {
   }
 
   if (options.deleteEntry) {
+    if (entry.deps) {
+      for (const depEntry of entry.deps) {
+        depEntry.contexts.delete(entry);
+      }
+      entry.deps = undefined;
+    }
+
+    if (entry.contexts) {
+      for (const context of entry.contexts) {
+        context.deps.delete(entry);
+      }
+      entry.contexts = undefined;
+    }
+
     deleteEntry(entry);
   }
 }


### PR DESCRIPTION
Relates to #229 

Still updating properties in a chain of the observer can lead to out-of-date UI, as the `render` method is added to the emitter queue when the first of its dependencies has changed. Added test to this PR shows that case - render is called after the `prop1` observer, so the `prop1` and `prop2` are updated, but before the `prop3` (it is added to the queue when render is there already).

However, the PR fixes the issue where the state after that action is broken, and `render` has no deps anymore (before calling `host.prop3 = ...` cleared out deps/contexts of a whole tree, so render has no deps then, but it also will not be called, as it was called already).