### PR TITLE
Update generic of type `Model<M>`

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -78,7 +78,7 @@ declare module "hybrids" {
 
   /* Store */
 
-  type Model<M> = {
+  type Model<M extends { id?: string } & object> = {
     [property in keyof Omit<M, "id">]: Required<M>[property] extends Array<
       infer T
     >


### PR DESCRIPTION
If the object that the user uses to create the model has an "id" property defined, then it must be a string. 

See https://github.com/hybridsjs/hybrids/commit/faec4c67cc255b60a705cd86c2ed8ef0f4703e3b