### PR TITLE
fix(define) types of property and descriptor

### DIFF
--- a/test/types/define/property-descriptor.ts
+++ b/test/types/define/property-descriptor.ts
@@ -1,12 +1,12 @@
 import { define } from "/types";
 
 interface IMyComponent extends HTMLElement {
-    booleanProperty1: boolean
-    booleanProperty2: boolean
-    booleanProperty3: boolean
-    booleanProperty4: boolean
-    booleanProperty5: boolean
-    booleanProperty6: boolean
+    primitiveProperty1: boolean
+    primitiveProperty2: boolean
+    primitiveProperty3: boolean
+    primitiveProperty4: boolean
+    primitiveProperty5: boolean
+    primitiveProperty6: boolean
     
     nonprimitiveProperty1: {}
     nonprimitiveProperty2: {}
@@ -22,25 +22,25 @@ define<IMyComponent>({
     // Regular
 
     // value
-    booleanProperty1: false,
+    primitiveProperty1: false,
     // getter
-    booleanProperty2: ({ booleanProperty1 }) => booleanProperty1,
+    primitiveProperty2: ({ primitiveProperty1 }) => primitiveProperty1,
     // setter
-    booleanProperty3: ({ booleanProperty1 }, value?: boolean) => value ?? booleanProperty1,
+    primitiveProperty3: ({ primitiveProperty1 }, value?: boolean) => value ?? primitiveProperty1,
 
     // Regular with Descriptor
 
     // value
-    booleanProperty4: {
+    primitiveProperty4: {
         value: false
     },
     // getter
-    booleanProperty5: {
-        value: ({ booleanProperty4 }) => booleanProperty4,
+    primitiveProperty5: {
+        value: ({ primitiveProperty4 }) => primitiveProperty4,
     },
     // setter
-    booleanProperty6: {
-        value: ({ booleanProperty1 }, value?: boolean) => value ?? booleanProperty1,
+    primitiveProperty6: {
+        value: ({ primitiveProperty1 }, value?: boolean) => value ?? primitiveProperty1,
     },
 
     // Exceptional case of non-primitives

--- a/test/types/define/property-descriptor.ts
+++ b/test/types/define/property-descriptor.ts
@@ -1,0 +1,70 @@
+import { define } from "/types";
+
+interface IMyComponent extends HTMLElement {
+    booleanProperty1: boolean
+    booleanProperty2: boolean
+    booleanProperty3: boolean
+    booleanProperty4: boolean
+    booleanProperty5: boolean
+    booleanProperty6: boolean
+    
+    nonprimitiveProperty1: {}
+    nonprimitiveProperty2: {}
+    nonprimitiveProperty3: {}
+    nonprimitiveProperty4: {}
+    nonprimitiveProperty5: {}
+    nonprimitiveProperty6: {}
+}
+
+define<IMyComponent>({
+    tag: "my-component",
+
+    // Regular
+
+    // value
+    booleanProperty1: false,
+    // getter
+    booleanProperty2: ({ booleanProperty1 }) => booleanProperty1,
+    // setter
+    booleanProperty3: ({ booleanProperty1 }, value?: boolean) => value ?? booleanProperty1,
+
+    // Regular with Descriptor
+
+    // value
+    booleanProperty4: {
+        value: false
+    },
+    // getter
+    booleanProperty5: {
+        value: ({ booleanProperty4 }) => booleanProperty4,
+    },
+    // setter
+    booleanProperty6: {
+        value: ({ booleanProperty1 }, value?: boolean) => value ?? booleanProperty1,
+    },
+
+    // Exceptional case of non-primitives
+
+    // value
+    /// @ts-expect-error A default value as an object instance can only be set using full object descriptor with `value` option!
+    nonprimitiveProperty1: {},
+    // getter
+    nonprimitiveProperty2: ({ nonprimitiveProperty1 }) => nonprimitiveProperty1,
+    // setter
+    nonprimitiveProperty3: ({ nonprimitiveProperty1 }, value?: object) => value ?? nonprimitiveProperty1,
+
+    // Exceptional case of non-primitives - Descriptor
+
+    nonprimitiveProperty4: {
+        // value
+        value: {},
+    },
+    nonprimitiveProperty5: {
+        // getter
+        value: ({ nonprimitiveProperty4 }) => nonprimitiveProperty4,
+    },
+    nonprimitiveProperty6: {
+        // setter
+        value: ({ nonprimitiveProperty4 }, value?: object) => value ?? nonprimitiveProperty4,
+    },
+})

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,14 +1,12 @@
 export type Property<E, V> =
   | (V extends string | number | boolean | null | undefined ? V : never)
-  | ((host: E & HTMLElement) => V)
-  | ((host: E & HTMLElement, value: any) => V)
+  | ((host: E & HTMLElement, value?: any) => V)
   | Descriptor<E, V>;
 
 export interface Descriptor<E, V> {
   value:
     | V
-    | ((host: E & HTMLElement) => V)
-    | ((host: E & HTMLElement, value: any) => V);
+    | ((host: E & HTMLElement, value?: any) => V);
 
   connect?(
     host: E & HTMLElement & { __property_key__: V },


### PR DESCRIPTION
A property with a getter was throwing a typing error, a descriptor with a getter was also throwing a typing error. Fixed